### PR TITLE
stratifiedobs for partitioning labeled data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,6 @@
+# v0.1
+
+New features:
+
+- added `stratifiedobs` to perform partitioning using stratified
+  sampling without replacement.

--- a/docs/introduction/gettingstarted.rst
+++ b/docs/introduction/gettingstarted.rst
@@ -295,10 +295,24 @@ set. In fact, it makes no difference.
 
 On the other hand, some functions require the presence of targets
 to perform their respective tasks. In such a case, it is always
-assumed that the last tuple element contains the targets. Two
-such functions are :func:`undersample` and :func:`oversample`,
-which can be used to re-sample a labeled data container in such a
-way, that the resulting class distribution is uniform.
+assumed that the last tuple element contains the targets. An
+alternative to :func:`splitobs` that is explicitly for labeled
+data is :func:`stratifiedobs`, which tries to preserve the class
+distribution. The following example shows that both, ``y1`` and
+``y2``, contain twice as much ``"b"`` as ``"a"``, just like ``y``
+does.
+
+.. code-block:: jlcon
+
+   julia> (X1, y1), (X2, y2) = stratifiedobs((X, y), p = 0.5);
+
+   julia> y1, y2
+   (String["a","b","b"],String["b","b","a"])
+
+Other functions that deal with supervised data sets are
+:func:`undersample` and :func:`oversample`, which can be used to
+re-sample a labeled data container in such a way, that the
+resulting class distribution is uniform.
 
 .. code-block:: jlcon
 
@@ -488,6 +502,8 @@ package can be utilized to solve them.
 - :ref:`Shuffle the observations of a data container. <shuffle>`
 
 - :ref:`Split data into train/test subsets. <split>`
+
+- :ref:`Split labeled data into train/test subsets. <stratified>`
 
 - :ref:`Group multiple variables together an treat as a single data set. <tuples>`
 

--- a/src/MLDataPattern.jl
+++ b/src/MLDataPattern.jl
@@ -9,6 +9,8 @@ using Compat
 using LearnBase: ObsDimension
 import LearnBase: nobs, getobs, getobs!, gettarget, gettargets, targets, datasubset, default_obsdim
 
+using Base.Cartesian
+
 export
 
     ObsDim,
@@ -34,6 +36,8 @@ export
     targets,
     eachtarget,
 
+    stratifiedobs,
+
     oversample,
     undersample,
     upsample,
@@ -56,6 +60,7 @@ include("shuffleobs.jl")
 include("splitobs.jl")
 include("dataview.jl")
 include("targets.jl")
+include("stratifiedobs.jl")
 include("resample.jl")
 include("folds.jl")
 include("dataiterator.jl")

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -1,7 +1,7 @@
 """
     oversample([f], data, [shuffle = true], [obsdim])
 
-Generates a class-balanced version of `data` by repeatedly
+Generate a class-balanced version of `data` by repeatedly
 sampling existing observations in such a way that the resulting
 number of observations will be the same number for every class.
 This way, all classes will have as many observations in the
@@ -37,47 +37,49 @@ X_bal, Y_bal = oversample((X,Y))
 
 For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref). For example, the following
-code allows `oversample` to work on a `DataFrame`.
+code allows `oversample` to work on a `DataTable`.
 
 ```julia
-# Make DataFrames.jl work
-LearnBase.getobs(data::DataFrame, i) = data[i,:]
-LearnBase.nobs(data::DataFrame) = nrow(data)
+# Make DataTables.jl work
+LearnBase.getobs(data::DataTable, i) = data[i,:]
+LearnBase.nobs(data::DataTable) = nrow(data)
 ```
 
-You can use the (keyword) parameter `f` to specify how to
-extract or retrieve the targets from each observation of the
-given `data`. Note that if `data` is a tuple, then it will be
-assumed that the last element of the tuple contains the targets
-and `f` will be applied to each observation in that element.
+You can use the parameter `f` to specify how to extract or
+retrieve the targets from each observation of the given `data`.
+Note that if `data` is a tuple, then it will be assumed that the
+last element of the tuple contains the targets and `f` will be
+applied to each observation in that element.
 
 ```julia
-julia> data = DataFrame(Any[rand(6), rand(6), [:a,:b,:b,:b,:b,:a]], [:X1,:X2,:Y])
-6×3 DataFrames.DataFrame
-│ Row │ X1       │ X2       │ Y │
-├─────┼──────────┼──────────┼───┤
-│ 1   │ 0.646593 │ 0.970426 │ a │
-│ 2   │ 0.363206 │ 0.479828 │ b │
-│ 3   │ 0.87524  │ 0.547199 │ b │
-│ 4   │ 0.618918 │ 0.661277 │ b │
-│ 5   │ 0.723626 │ 0.295239 │ b │
-│ 6   │ 0.147621 │ 0.527292 │ a │
+julia> data = DataTable(Any[rand(6), rand(6), [:a,:b,:b,:b,:b,:a]], [:X1,:X2,:Y])
+6×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.226582  │ 0.0443222   │ a │
+│ 2   │ 0.504629  │ 0.722906    │ b │
+│ 3   │ 0.933372  │ 0.812814    │ b │
+│ 4   │ 0.522172  │ 0.245457    │ b │
+│ 5   │ 0.505208  │ 0.11202     │ b │
+│ 6   │ 0.0997825 │ 0.000341996 │ a │
 
 julia> getobs(oversample(row->row[:Y], data))
-8×3 DataFrames.DataFrame
-│ Row │ X1       │ X2       │ Y │
-├─────┼──────────┼──────────┼───┤
-│ 1   │ 0.646593 │ 0.970426 │ a │
-│ 2   │ 0.618918 │ 0.661277 │ b │
-│ 3   │ 0.147621 │ 0.527292 │ a │
-│ 4   │ 0.646593 │ 0.970426 │ a │
-│ 5   │ 0.723626 │ 0.295239 │ b │
-│ 6   │ 0.363206 │ 0.479828 │ b │
-│ 7   │ 0.147621 │ 0.527292 │ a │
-│ 8   │ 0.87524  │ 0.547199 │ b │
+8×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.0997825 │ 0.000341996 │ a │
+│ 2   │ 0.505208  │ 0.11202     │ b │
+│ 3   │ 0.226582  │ 0.0443222   │ a │
+│ 4   │ 0.0997825 │ 0.000341996 │ a │
+│ 5   │ 0.504629  │ 0.722906    │ b │
+│ 6   │ 0.522172  │ 0.245457    │ b │
+│ 7   │ 0.226582  │ 0.0443222   │ a │
+│ 8   │ 0.933372  │ 0.812814    │ b │
 ```
 
-see also [`undersample`](@ref).
+see [`DataSubset`](@ref) for more information on data subsets.
+
+see also [`undersample`](@ref) and [`stratifiedobs`](@ref).
 """
 oversample(data; shuffle=true, obsdim=default_obsdim(data)) =
     oversample(identity, data, shuffle, convert(LearnBase.ObsDimension,obsdim))
@@ -112,7 +114,7 @@ end
 """
     undersample([f], data, [shuffle = false], [obsdim])
 
-Generates a class-balanced version of `data` by subsampling its
+Generate a class-balanced version of `data` by subsampling its
 observations in such a way that the resulting number of
 observations will be the same number for every class. This way,
 all classes will have as many observations in the resulting data
@@ -147,43 +149,45 @@ X_bal, Y_bal = undersample((X,Y))
 
 For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref). For example, the following
-code allows `undersample` to work on a `DataFrame`.
+code allows `undersample` to work on a `DataTable`.
 
 ```julia
-# Make DataFrames.jl work
-LearnBase.getobs(data::DataFrame, i) = data[i,:]
-LearnBase.nobs(data::DataFrame) = nrow(data)
+# Make DataTables.jl work
+LearnBase.getobs(data::DataTable, i) = data[i,:]
+LearnBase.nobs(data::DataTable) = nrow(data)
 ```
 
-You can use the (keyword) parameter `f` to specify how to
-extract or retrieve the targets from each observation of the
-given `data`. Note that if `data` is a tuple, then it will be
-assumed that the last element of the tuple contains the targets
-and `f` will be applied to each observation in that element.
+You can use the parameter `f` to specify how to extract or
+retrieve the targets from each observation of the given `data`.
+Note that if `data` is a tuple, then it will be assumed that the
+last element of the tuple contains the targets and `f` will be
+applied to each observation in that element.
 
 ```julia
-julia> data = DataFrame(Any[rand(6), rand(6), [:a,:b,:b,:b,:b,:a]], [:X1,:X2,:Y])
-6×3 DataFrames.DataFrame
-│ Row │ X1       │ X2       │ Y │
-├─────┼──────────┼──────────┼───┤
-│ 1   │ 0.646593 │ 0.970426 │ a │
-│ 2   │ 0.363206 │ 0.479828 │ b │
-│ 3   │ 0.87524  │ 0.547199 │ b │
-│ 4   │ 0.618918 │ 0.661277 │ b │
-│ 5   │ 0.723626 │ 0.295239 │ b │
-│ 6   │ 0.147621 │ 0.527292 │ a │
+julia> data = DataTable(Any[rand(6), rand(6), [:a,:b,:b,:b,:b,:a]], [:X1,:X2,:Y])
+6×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.226582  │ 0.0443222   │ a │
+│ 2   │ 0.504629  │ 0.722906    │ b │
+│ 3   │ 0.933372  │ 0.812814    │ b │
+│ 4   │ 0.522172  │ 0.245457    │ b │
+│ 5   │ 0.505208  │ 0.11202     │ b │
+│ 6   │ 0.0997825 │ 0.000341996 │ a │
 
 julia> getobs(undersample(row->row[:Y], data))
-4×3 DataFrames.DataFrame
-│ Row │ X1       │ X2       │ Y │
-├─────┼──────────┼──────────┼───┤
-│ 1   │ 0.646593 │ 0.970426 │ a │
-│ 2   │ 0.363206 │ 0.479828 │ b │
-│ 3   │ 0.618918 │ 0.661277 │ b │
-│ 4   │ 0.147621 │ 0.527292 │ a │
+4×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.226582  │ 0.0443222   │ a │
+│ 2   │ 0.504629  │ 0.722906    │ b │
+│ 3   │ 0.522172  │ 0.245457    │ b │
+│ 4   │ 0.0997825 │ 0.000341996 │ a │
 ```
 
-see also [`oversample`](@ref).
+see [`DataSubset`](@ref) for more information on data subsets.
+
+see also [`oversample`](@ref) and [`stratifiedobs`](@ref).
 """
 undersample(data; shuffle=false, obsdim=default_obsdim(data)) =
     undersample(identity, data, shuffle, convert(LearnBase.ObsDimension,obsdim))

--- a/src/splitobs.jl
+++ b/src/splitobs.jl
@@ -41,7 +41,7 @@ _ispos(x) = x > 0
 end
 
 """
-    splitobs(data, [at = 0.7], [obsdim])
+    splitobs(data, [at = 0.7], [obsdim]) -> Tuple
 
 Split the `data` into multiple subsets proportional to the
 value(s) of `at`.
@@ -105,7 +105,10 @@ train, test = splitobs((X,y), 0.7)
 train, test = splitobs((X,y), 0.7, ObsDim.First())
 ```
 
-see [`DataSubset`](@ref) for more information.
+see [`DataSubset`](@ref) for more information on data subsets.
+
+see [`stratifiedobs`](@ref) for a related function that preserves
+the target distribution.
 """
 splitobs(data; at = 0.7, obsdim = default_obsdim(data)) =
     splitobs(data, at, convert(LearnBase.ObsDimension,obsdim))

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -1,0 +1,75 @@
+splitobs{T,I<:Integer}(lm::Dict{T,Vector{I}}; at = 0.7) =
+    splitobs(lm, at)
+
+function splitobs{T,I<:Integer}(lm::Dict{T,Vector{I}}, at::AbstractFloat)
+    0 < at < 1 || throw(ArgumentError("the parameter \"at\" must be in interval (0, 1)"))
+    n = mapreduce(length, +, values(lm))
+    k = nlabel(lm)
+    # preallocate the indices vectors
+    idx1 = Vector{I}()
+    idx2 = Vector{I}()
+    # sizehint will save us a few heavy memory allocations
+    # we specify "+ k" to deal with trailing observations when
+    # the number of observations from a class isn't divideable
+    # by "at" or "1-at"
+    sizehint!(idx1, ceil(Int, n * at     + k))
+    sizehint!(idx2, ceil(Int, n * (1-at) + k))
+    # loop through all label indices
+    for indices in values(lm)
+        i1, i2 = splitobs(indices, at)
+        append!(idx1, i1)
+        append!(idx2, i2)
+    end
+    idx1, idx2
+end
+
+# we use @generated because we compute "N+1"
+@generated function splitobs{T,I<:Integer,N}(lm::Dict{T,Vector{I}}, at::NTuple{N,AbstractFloat})
+    quote
+        (all(map(_ispos, at)) && sum(at) < 1) || throw(ArgumentError("all elements in \"at\" must be positive and their sum must be smaller than 1"))
+        n = mapreduce(length, +, values(lm))
+        k = nlabel(lm)
+        # preallocate the indices vectors
+        @nexprs $(N+1) i -> idx_i = Vector{I}()
+        # sizehint will save us a few heavy memory allocations
+        # we specify "+ k" to deal with trailing observations when
+        # the number of observations from a class isn't divideable
+        # by "at" or "1-at"
+        @nexprs $(N)   i -> sizehint!(idx_i, ceil(Int, n*at[i] + k))
+        sizehint!($(Symbol(:idx_, Symbol(N+1))), ceil(Int, n*(1-sum(at)) + k))
+        # loop through all label indices
+        for indices in values(lm)
+            tup = splitobs(indices, at)
+            @nexprs $(N+1) i -> append!(idx_i, tup[i])
+        end
+        # return a tuple of all indices vectors
+        @ntuple $(N+1) idx
+    end
+end
+
+function stratifiedobs(data; p = 0.7, shuffle = true, obsdim = default_obsdim(data))
+    stratifiedobs(identity, data, p, shuffle, convert(ObsDimension, obsdim))
+end
+
+function stratifiedobs(f, data; p = 0.7, shuffle = true, obsdim = default_obsdim(data))
+    stratifiedobs(f, data, p, shuffle, convert(ObsDimension, obsdim))
+end
+
+function stratifiedobs(data, p::AbstractFloat, args...)
+    stratifiedobs(identity, data, p, args...)
+end
+
+function stratifiedobs{N}(data, p::NTuple{N,AbstractFloat}, args...)
+    stratifiedobs(identity, data, p, args...)
+end
+
+function stratifiedobs(f, data, p::Union{NTuple,AbstractFloat}, shuffle::Bool = true, obsdim = default_obsdim(data))
+    # The given data is always shuffled to qualify as performing
+    # stratified sampling without replacement.
+    data_shuf = shuffleobs(data, obsdim)
+    idx_tup = splitobs(labelmap(eachtarget(f, data_shuf, obsdim)), p)
+    # Setting the parameter "shuffle = false" specifies that the
+    # classes are ordered in the resulting subsets respectively.
+    shuffle && foreach(shuffle!, idx_tup)
+    map(idx -> datasubset(data_shuf, idx, obsdim), idx_tup)
+end

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -23,7 +23,6 @@ function splitobs{T,I<:Integer}(lm::Dict{T,Vector{I}}, at::AbstractFloat)
     idx1, idx2
 end
 
-# we use @generated because we compute "N+1"
 @generated function splitobs{T,I<:Integer,N}(lm::Dict{T,Vector{I}}, at::NTuple{N,AbstractFloat})
     quote
         (all(map(_ispos, at)) && sum(at) < 1) || throw(ArgumentError("all elements in \"at\" must be positive and their sum must be smaller than 1"))
@@ -35,7 +34,7 @@ end
         # we specify "+ k" to deal with trailing observations when
         # the number of observations from a class isn't divideable
         # by "at" or "1-at"
-        @nexprs $(N)   i -> sizehint!(idx_i, ceil(Int, n*at[i] + k))
+        @nexprs $(N) i -> sizehint!(idx_i, ceil(Int, n*at[i] + k))
         sizehint!($(Symbol(:idx_, Symbol(N+1))), ceil(Int, n*(1-sum(at)) + k))
         # loop through all label indices
         for indices in values(lm)
@@ -47,6 +46,130 @@ end
     end
 end
 
+"""
+    stratifiedobs([f], data, [p = 0.7], [shuffle = true], [obsdim]) -> Tuple
+
+Partitition the `data` into multiple disjoint subsets
+proportional to the value(s) of `p` by using stratified sampling
+without replacement. These data subsets are then returned as a
+`Tuple`, where the first element contains the fraction of
+observations of `data` that is specified by `p`.
+
+For example, if `p` is a `Float64` then the return-value will be
+a tuple with two elements (i.e. subsets), in which the first
+element contains the fracion of observations specified by `p` and
+the second element contains the rest. In the following code the
+first subset `train` will contain the around 70% of the
+observations and the second subset `test` the rest.
+
+```julia
+train, test = stratifiedobs(X, p = 0.7)
+```
+
+If `p` is a tuple of `Float64` then additional subsets will be
+created. In this example `train` will contain about 50% of the
+observations, `val` will contain around 30%, and `test` the
+remaining 20%.
+
+```julia
+train, val, test = stratifiedobs(X, p = (0.5, 0.3))
+```
+
+It is also possible to call `stratifiedobs` with multiple data
+arguments as tuple, which all must have the same number of total
+observations. Note that if `data` is a tuple, then it will be
+assumed that the last element of the tuple contains the targets.
+
+```julia
+train, test = stratifiedobs((X, y), p = 0.7)
+(X_train,y_train), (X_test,y_test) = stratifiedobs((X, y), p = 0.7)
+```
+
+The optional parameter `shuffle` determines if the resulting data
+subsets should be shuffled. If `false`, then the observations in
+the subsets will be grouped together according to their labels.
+
+```julia
+julia> Y = ["a", "b", "b", "b", "b", "a"] # 2 imbalanced classes
+6-element Array{String,1}:
+ "a"
+ "b"
+ "b"
+ "b"
+ "b"
+ "a"
+
+julia> train, test = stratifiedobs(Y, p = 0.5, shuffle = false)
+(String["b","b","a"],String["b","b","a"])
+```
+
+The optional parameter `obsdim` can be used to specify which
+dimension denotes the observations, if that concept makes sense
+for the type of `data`. See `?ObsDim` for more information.
+
+```julia
+# 2 imbalanced classes in one-of-k encoding
+julia> X = [1 0; 1 0; 1 0; 1 0; 0 1; 0 1]
+6×2 Array{Int64,2}:
+ 1  0
+ 1  0
+ 1  0
+ 1  0
+ 0  1
+ 0  1
+
+julia> train, test = stratifiedobs(indmax, X, p = 0.5, obsdim = 1)
+([1 0; 1 0; 0 1], [0 1; 1 0; 1 0])
+```
+
+For this function to work, the type of `data` must implement
+[`nobs`](@ref) and [`getobs`](@ref). For example, the following
+code allows `stratifiedobs` to work on a `DataTable`.
+
+```julia
+# Make DataTables.jl work
+LearnBase.getobs(data::DataTable, i) = data[i,:]
+LearnBase.nobs(data::DataTable) = nrow(data)
+```
+
+You can use the parameter `f` to specify how to extract or
+retrieve the targets from each observation of the given `data`.
+
+```julia
+julia> data = DataTable(Any[rand(6), rand(6), [:a,:b,:b,:b,:b,:a]], [:X1,:X2,:Y])
+6×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.226582  │ 0.0443222   │ a │
+│ 2   │ 0.504629  │ 0.722906    │ b │
+│ 3   │ 0.933372  │ 0.812814    │ b │
+│ 4   │ 0.522172  │ 0.245457    │ b │
+│ 5   │ 0.505208  │ 0.11202     │ b │
+│ 6   │ 0.0997825 │ 0.000341996 │ a │
+
+julia> train, test = stratifiedobs(row->row[:Y], data, 0.5);
+
+julia> getobs(train)
+3×3 DataTables.DataTable
+│ Row │ X1        │ X2          │ Y │
+├─────┼───────────┼─────────────┼───┤
+│ 1   │ 0.933372  │ 0.812814    │ b │
+│ 2   │ 0.522172  │ 0.245457    │ b │
+│ 3   │ 0.0997825 │ 0.000341996 │ a │
+
+julia> getobs(test)
+3×3 DataTables.DataTable
+│ Row │ X1       │ X2        │ Y │
+├─────┼──────────┼───────────┼───┤
+│ 1   │ 0.504629 │ 0.722906  │ b │
+│ 2   │ 0.226582 │ 0.0443222 │ a │
+│ 3   │ 0.505208 │ 0.11202   │ b │
+```
+
+see [`DataSubset`](@ref) for more information on data subsets.
+
+see also [`undersample`](@ref), [`oversample`](@ref), [`splitobs`](@ref).
+"""
 function stratifiedobs(data; p = 0.7, shuffle = true, obsdim = default_obsdim(data))
     stratifiedobs(identity, data, p, shuffle, convert(ObsDimension, obsdim))
 end

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -49,21 +49,24 @@ end
 """
     stratifiedobs([f], data, [p = 0.7], [shuffle = true], [obsdim]) -> Tuple
 
-Partitition the `data` into multiple disjoint subsets
-proportional to the value(s) of `p` by using stratified sampling
-without replacement. These data subsets are then returned as a
-`Tuple`, where the first element contains the fraction of
-observations of `data` that is specified by `p`.
+Partition the `data` into multiple disjoint subsets proportional
+to the value(s) of `p`. The observations are assignmed to a data
+subset using stratified sampling without replacement. These
+subsets are then returned as a `Tuple` of subsets, where the
+first element contains the fraction of observations of `data`
+that is specified by the first float in `p`.
 
-For example, if `p` is a `Float64` then the return-value will be
-a tuple with two elements (i.e. subsets), in which the first
-element contains the fracion of observations specified by `p` and
-the second element contains the rest. In the following code the
-first subset `train` will contain the around 70% of the
-observations and the second subset `test` the rest.
+For example, if `p` is a `Float64` itself, then the return-value
+will be a tuple with two elements (i.e. subsets), in which the
+first element contains the fraction of observations specified by
+`p` and the second element contains the rest. In the following
+code the first subset `train` will contain around 70% of the
+observations and the second subset `test` the rest. The key
+difference to [`splitobs`](@ref) is that the class distribution
+in `y` will actively be preserved in `train` and `test`.
 
 ```julia
-train, test = stratifiedobs(X, p = 0.7)
+train, test = stratifiedobs(y, p = 0.7)
 ```
 
 If `p` is a tuple of `Float64` then additional subsets will be
@@ -72,7 +75,7 @@ observations, `val` will contain around 30%, and `test` the
 remaining 20%.
 
 ```julia
-train, val, test = stratifiedobs(X, p = (0.5, 0.3))
+train, val, test = stratifiedobs(y, p = (0.5, 0.3))
 ```
 
 It is also possible to call `stratifiedobs` with multiple data
@@ -90,7 +93,7 @@ subsets should be shuffled. If `false`, then the observations in
 the subsets will be grouped together according to their labels.
 
 ```julia
-julia> Y = ["a", "b", "b", "b", "b", "a"] # 2 imbalanced classes
+julia> y = ["a", "b", "b", "b", "b", "a"] # 2 imbalanced classes
 6-element Array{String,1}:
  "a"
  "b"
@@ -99,7 +102,7 @@ julia> Y = ["a", "b", "b", "b", "b", "a"] # 2 imbalanced classes
  "b"
  "a"
 
-julia> train, test = stratifiedobs(Y, p = 0.5, shuffle = false)
+julia> train, test = stratifiedobs(y, p = 0.5, shuffle = false)
 (String["b","b","a"],String["b","b","a"])
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,6 +58,7 @@ tests = [
     "tst_splitobs.jl"
     "tst_dataview.jl"
     "tst_targets.jl"
+    "tst_stratifiedobs.jl"
     "tst_resample.jl"
     "tst_folds.jl"
     "tst_dataiterator.jl"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using MLDataPattern
 # --------------------------------------------------------------------
 # create some test data
 
+srand(1335)
 X = rand(4, 150)
 y = repeat(["setosa","versicolor","virginica"], inner = 50)
 Y = permutedims(hcat(y,y), [2,1])

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -12,6 +12,7 @@ end
 
 @testset "Type Stability" begin
     for var in vars
+        srand(1335)
         @test_throws ArgumentError stratifiedobs(var, 0.)
         @test_throws ArgumentError stratifiedobs(var, 1.)
         @test_throws ArgumentError stratifiedobs(var, (0.2,0.0))
@@ -27,6 +28,7 @@ end
         @test eltype(@inferred(stratifiedobs(var, 0.5, true, ObsDim.First()))) <: SubArray
     end
     for tup in tuples
+        srand(1335)
         @test_throws ArgumentError stratifiedobs(tup, 0.)
         @test_throws ArgumentError stratifiedobs(tup, 1.)
         @test_throws ArgumentError stratifiedobs(tup, (0.2,0.0))

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -4,10 +4,10 @@
 srand(1335)
 
 ty = [:a, :a, :a, :a, :a, :a, :b, :b, :b, :b]
-if Int === Int64
-    @test splitobs(labelmap(ty), at = 0.5) == ([1,2,3,7,8],[4,5,6,9,10])
-else
+if Int === Int32 && VERSION < v"0.6-"
     @test splitobs(labelmap(ty), at = 0.5) == ([7,8,1,2,3],[9,10,4,5,6])
+else
+    @test splitobs(labelmap(ty), at = 0.5) == ([1,2,3,7,8],[4,5,6,9,10])
 end
 
 @testset "Type Stability" begin

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -1,0 +1,76 @@
+@test_throws DimensionMismatch stratifiedobs((X, rand(149)))
+@test_throws DimensionMismatch stratifiedobs((X, rand(149)), obsdim=:last)
+
+ty = [:a, :a, :a, :a, :a, :a, :b, :b, :b, :b]
+@test splitobs(labelmap(ty), at = 0.5) == ([1,2,3,7,8],[4,5,6,9,10])
+
+@testset "Type Stability" begin
+    for var in vars
+        @test_throws ArgumentError stratifiedobs(var, 0.)
+        @test_throws ArgumentError stratifiedobs(var, 1.)
+        @test_throws ArgumentError stratifiedobs(var, (0.2,0.0))
+        @test_throws ArgumentError stratifiedobs(var, (0.2,0.8))
+        @test_throws MethodError stratifiedobs(var, 0.5, ObsDim.Undefined())
+        @test typeof(@inferred(stratifiedobs(var))) <: NTuple{2}
+        @test eltype(@inferred(stratifiedobs(var))) <: SubArray
+        @test typeof(@inferred(stratifiedobs(var, 0.5))) <: NTuple{2}
+        @test typeof(@inferred(stratifiedobs(var, 0.5, true))) <: NTuple{2}
+        @test typeof(@inferred(stratifiedobs(var, (0.5,0.2)))) <: NTuple{3}
+        @test typeof(@inferred(stratifiedobs(var, 0.5, true, ObsDim.Last()))) <: NTuple{2}
+        @test typeof(@inferred(stratifiedobs(var, 0.5, true, ObsDim.First()))) <: NTuple{2}
+        @test eltype(@inferred(stratifiedobs(var, 0.5, true, ObsDim.First()))) <: SubArray
+    end
+    for tup in tuples
+        @test_throws ArgumentError stratifiedobs(tup, 0.)
+        @test_throws ArgumentError stratifiedobs(tup, 1.)
+        @test_throws ArgumentError stratifiedobs(tup, (0.2,0.0))
+        @test_throws ArgumentError stratifiedobs(tup, (0.2,0.8))
+        @test_throws MethodError stratifiedobs(tup, 0.5, ObsDim.Undefined())
+        @test typeof(@inferred(stratifiedobs(tup))) <: NTuple{2}
+        @test eltype(@inferred(stratifiedobs(tup))) <: Tuple
+        @test typeof(@inferred(stratifiedobs(tup, 0.5))) <: NTuple{2}
+        @test typeof(@inferred(stratifiedobs(tup, 0.5, true))) <: NTuple{2}
+        @test typeof(@inferred(stratifiedobs(tup, (0.5,0.2)))) <: NTuple{3}
+        @test typeof(@inferred(stratifiedobs(tup, 0.5, true, ObsDim.Last()))) <: NTuple{2}
+    end
+end
+
+println("<HEARTBEAT>")
+
+@testset "SparseArray" begin
+    @test nobs.(stratifiedobs(round, ys)) == (105,45)
+    @test nobs.(stratifiedobs(round, ys, p=0.7)) == (105,45)
+    @test nobs.(stratifiedobs(round, ys, p=(.2,.3))) == (30,45,75)
+    @test nobs.(stratifiedobs(round, ys, p=(.2,.3), obsdim=:last)) == (30,45,75)
+    @test nobs.(stratifiedobs(round, ys, p=(.1,.2,.3))) == (15,30,45,60)
+end
+
+@testset "Array, and SubArray" begin
+    for var in (yv, y)
+        @test nobs.(stratifiedobs(var)) == (105,45)
+        @test nobs.(stratifiedobs(x->x, var)) == (105,45)
+        @test nobs.(stratifiedobs(var, p=0.7)) == (105,45)
+        @test nobs.(stratifiedobs(x->x, var, p=0.7)) == (105,45)
+        @test nobs.(stratifiedobs(var, p=(.2,.3))) == (30,45,75)
+        @test nobs.(stratifiedobs(var, p=(.2,.3), obsdim=:last)) == (30,45,75)
+        @test nobs.(stratifiedobs(var, p=(.1,.2,.3))) == (15,30,45,60)
+    end
+    ty = [:a, :a, :a, :a, :a, :a, :b, :b, :b, :b]
+    train, test = @inferred stratifiedobs(ty, 0.5, false)
+    @test train == [:a, :a, :a, :b, :b] || train == [:b, :b, :a, :a, :a]
+    @test test == [:a, :a, :a, :b, :b] || test == [:b, :b, :a, :a, :a]
+
+    train, test = @inferred stratifiedobs(x->x, ty, 0.5, false)
+    @test train == [:a, :a, :a, :b, :b] || train == [:b, :b, :a, :a, :a]
+    @test test == [:a, :a, :a, :b, :b] || test == [:b, :b, :a, :a, :a]
+
+    train, test, val = @inferred stratifiedobs(ty, (0.5,0.3), false)
+    @test train == [:a, :a, :a, :b, :b] || train == [:b, :b, :a, :a, :a]
+    @test test == [:a, :a, :b] || test == [:b, :a, :a]
+    @test val == [:a, :b] || val == [:b, :a]
+
+    ty = [:a, :a, :a, :a, :a, :a, :b, :b, :b, :b, :c, :c]
+    train, test = @inferred stratifiedobs(ty, 0.5, false)
+    @test train == [:c, :a, :a, :a, :b, :b] || train == [:a, :a, :a, :c, :b, :b] || train == [:b, :b, :c, :a, :a, :a] || train == [:c, :b, :b, :a, :a, :a] || train == [:b, :b, :a, :a, :a, :c] || train == [:a, :a, :a, :b, :b, :c]
+    @test test == [:c, :a, :a, :a, :b, :b] || test == [:a, :a, :a, :c, :b, :b] || test == [:b, :b, :c, :a, :a, :a] || test == [:c, :b, :b, :a, :a, :a] || test == [:b, :b, :a, :a, :a, :c] || test == [:a, :a, :a, :b, :b, :c]
+end

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -1,8 +1,14 @@
 @test_throws DimensionMismatch stratifiedobs((X, rand(149)))
 @test_throws DimensionMismatch stratifiedobs((X, rand(149)), obsdim=:last)
 
+srand(1335)
+
 ty = [:a, :a, :a, :a, :a, :a, :b, :b, :b, :b]
-@test splitobs(labelmap(ty), at = 0.5) == ([1,2,3,7,8],[4,5,6,9,10])
+if Int === Int64
+    @test splitobs(labelmap(ty), at = 0.5) == ([1,2,3,7,8],[4,5,6,9,10])
+else
+    @test splitobs(labelmap(ty), at = 0.5) == ([7,8,1,2,3],[9,10,4,5,6])
+end
 
 @testset "Type Stability" begin
     for var in vars
@@ -37,6 +43,7 @@ end
 
 println("<HEARTBEAT>")
 
+srand(1335)
 @testset "SparseArray" begin
     @test nobs.(stratifiedobs(round, ys)) == (105,45)
     @test nobs.(stratifiedobs(round, ys, p=0.7)) == (105,45)


### PR DESCRIPTION
Allows a `splitobs(shuffleobs(...))` variant that makes sure the class distribution is as preserved as can be without repeating data

```julia
julia> y = vcat(fill(:a, 6), fill(:b, 4))
10-element Array{Symbol,1}:
 :a
 :a
 :a
 :a
 :a
 :a
 :b
 :b
 :b
 :b

julia> train, test = stratifiedobs(y, p = 0.5) # p ... proportion of observations in train
(Symbol[:a,:a,:b,:b,:a],Symbol[:a,:b,:a,:a,:b])
```

also with target extraction function. similar to `oversample`

```julia
julia> X = [1 0; 1 0; 1 0; 1 0; 0 1; 0 1]
6×2 Array{Int64,2}:
 1  0
 1  0
 1  0
 1  0
 0  1
 0  1

julia> train, test = stratifiedobs(indmax, X, p = 0.5, obsdim = 1)
([1 0; 0 1; 1 0],
 [1 0; 1 0; 0 1])
```

## TODO

- [x] Write tests
- [x] Allow `p` to be a tuple of floats
- [x] Write docstring for `stratifiedobs`
- [x] Write readthedocs section under "Labeled Data Container"