### PR TITLE
add maxsize keyword to batchview and eachbatch. fixes #8

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# v0.1.1
+
+Small API additions:
+
+- added `maxsize` keyword argument to `eachbatch` and `batchview`
+
 # v0.1
 
 New features:

--- a/docs/documentation/dataview.rst
+++ b/docs/documentation/dataview.rst
@@ -327,21 +327,30 @@ data container as a vector of equal-sized batches.
    which in general avoids data movement until :func:`getobs` is
    invoked.
 
-.. function:: batchview(data, [size], [count], [obsdim]) -> BatchView
+.. function:: batchview(data, [size|maxsize], [count], [obsdim]) -> BatchView
 
    Create a :class:`BatchView` for the given `data` container. It
    will serve as a vector-like view into `data`, where every
    element of the vector points to a batch of `size` observations
    from `data`. The number of batches and the batch-size can be
-   specified using (keyword) parameters `count` and `size`. In
-   the case that the size of the dataset is not dividable by the
-   specified (or inferred) `size`, the remaining observations
-   will be ignored.
+   specified using (keyword) parameters `count` and `size` (or
+   alternatively `maxsize`).
+
+   In the case that the size of the dataset is not dividable by
+   the specified (or inferred) `size`, the remaining observations
+   will be ignored. If `maxsize` is provided instead of `size`,
+   then the next dividable size will be used such that no
+   observations are ignored.
 
    :param data: The object representing a data container.
 
-   :param Integer size: Optional. The number of observations in
-                        each batch.
+   :param Integer size: Optional. The exact number of observations
+                        in each batch.
+
+   :param Integer maxsize: Optional alternative to `size`. The
+                           maximal number of observations in each
+                           batch, such that all observations get
+                           used.
 
    :param Integer count: \
         Optional. The number of batches that should be used. This
@@ -381,6 +390,14 @@ message.
    2-element MLDataPattern.BatchView{SubArray{Float64,2,Array{Float64,2},Tuple{Colon,UnitRange{Int64}},true},Array{Float64,2},LearnBase.ObsDim.Last}:
     [0.226582 0.933372; 0.504629 0.522172]
     [0.505208 0.0443222; 0.0997825 0.722906]
+
+   julia> bv = batchview(X, maxsize = 2)
+   5-element MLDataPattern.BatchView{SubArray{Float64,2,Array{Float64,2},Tuple{Colon,UnitRange{Int64}},true},Array{Float64,2},LearnBase.ObsDim.Last}:
+    [0.226582; 0.504629]
+    [0.933372; 0.522172]
+    [0.505208; 0.0997825]
+    [0.0443222; 0.722906]
+    [0.812814; 0.245457]
 
 You can query the size of each batch by using the function
 :func:`batchsize` on any :class:`BatchView`.

--- a/src/dataiterator.jl
+++ b/src/dataiterator.jl
@@ -505,14 +505,22 @@ see [`BufferGetObs`](@ref), [`batchview`](@ref), and
 [`getobs!`](@ref) for more info. also see [`eachobs`](@ref) for a
 single-observation version.
 """
-eachbatch(data; size = -1, count = -1, obsdim = default_obsdim(data)) =
-    BufferGetObs(BatchView(data, size, count, convert(LearnBase.ObsDimension,obsdim)))
+function eachbatch(data; size = -1, maxsize = -1, count = -1, obsdim = default_obsdim(data))
+    maxsize != -1 && size != -1 && throw(ArgumentError("Providing both \"size\" and \"maxsize\" is not supported"))
+    if maxsize != -1
+        # set upto to true in order to allow a flexible batch size
+        BufferGetObs(BatchView(data, maxsize, count, convert(LearnBase.ObsDimension,obsdim), true))
+    else
+        # force given batch size
+        BufferGetObs(BatchView(data, size, count, convert(LearnBase.ObsDimension,obsdim)))
+    end
+end
 
 eachbatch{T<:Union{Tuple,ObsDimension}}(data, obsdim::T) =
     BufferGetObs(BatchView(data, -1, -1, obsdim))
 
-eachbatch{T<:Union{Tuple,ObsDimension}}(data, size::Int, obsdim::T = default_obsdim(data)) =
-    BufferGetObs(BatchView(data, size, -1, obsdim))
+eachbatch{T<:Union{Tuple,ObsDimension}}(data, size::Int, obsdim::T = default_obsdim(data), upto::Bool = false) =
+    BufferGetObs(BatchView(data, size, -1, obsdim, upto))
 
-eachbatch{T<:Union{Tuple,ObsDimension}}(data, size::Int, count::Int, obsdim::T = default_obsdim(data)) =
-    BufferGetObs(BatchView(data, size, count, obsdim))
+eachbatch{T<:Union{Tuple,ObsDimension}}(data, size::Int, count::Int, obsdim::T = default_obsdim(data), upto::Bool = false) =
+    BufferGetObs(BatchView(data, size, count, obsdim, upto))

--- a/test/tst_dataiterator.jl
+++ b/test/tst_dataiterator.jl
@@ -424,6 +424,8 @@ end
     @test size(A.buffer) == (30,4)
     @test length(A) == 5
     A = @inferred eachbatch(X, 10)
+    @test_throws ArgumentError eachbatch(X, size = 10, maxsize = 11)
+    @test length(A) == length(eachbatch(X, maxsize = 11))
     @inferred first(A)
     @test typeof(A) <: BufferGetObs
     @test typeof(A.iter) <: BatchView

--- a/test/tst_dataview.jl
+++ b/test/tst_dataview.jl
@@ -142,6 +142,8 @@ end
 @testset "_compute_batch_settings" begin
     @test MLDataPattern._compute_batch_settings(X) === (30,5)
     @test MLDataPattern._compute_batch_settings(X',-1,-1,ObsDim.First()) === (30,5)
+    @test MLDataPattern._compute_batch_settings(X',32,-1,ObsDim.First()) === (32,4)
+    @test MLDataPattern._compute_batch_settings(X',32,-1,ObsDim.First(),true) === (30,5)
     @test MLDataPattern._compute_batch_settings(Xv) === (30,5)
     @test MLDataPattern._compute_batch_settings(Xs) === (30,5)
     @test MLDataPattern._compute_batch_settings(DataSubset(X)) === (30,5)
@@ -254,6 +256,8 @@ end
             @test @inferred(A[[1,3]]) == BatchView(datasubset(var, [1:15..., 31:45...]), 15)
         end
         A = BatchView(X',size=15,obsdim=1)
+        @test_throws ArgumentError BatchView(X',size=15, maxsize=15, obsdim=1)
+        @test A == BatchView(X',maxsize=16,obsdim=1)
         @test A == BatchView(X',count=10,obsdim=1)
         @test @inferred(length(A)) == 10
         @test @inferred(size(A)) == (10,)


### PR DESCRIPTION
Implements #8 

I opted for using an alternative keyword to `size` called `maxsize` instead of introducing a 2-step process there. The keyword-based API is for convenience after all

cc: @oxinabox 