### PR TITLE
Add `slidingwindow` function for preparing sequence data

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 - drop julia 0.5 support.
 
+New features:
+
+- added `slidingwindow` to help prepare sequence data for
+  training.
+
 Small changes:
 
 - rework how `FoldsView` is displayed.

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,11 @@ Small changes:
 
 - add test dependency on `ReferenceTests.jl`.
 
+Fixes:
+
+- disallow certain functions on `DataView` that don't work the
+  way a user would expect.
+
 # v0.1.2
 
 Small changes:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,9 +148,16 @@ views**, that will allow us to perform such iteration-pattern
 conveniently for data containers. In fact, they are more than
 "just" data iterators; they are proper vectors. As such, they
 also serve as a tool to "view" a data container from a specific
-aspect: As a sequence of observations, or a sequences of batches.
+aspect: As a vector of observations, or a vector of batches.
 Thus these views know how many observations they contain, and how
 to query specific parts of the data.
+
+Furthermore, we also provide a convenient way to partition a long
+sequence of data (e.g. some text or time-series) into a vector
+of smaller sequences. This is done using a sliding window
+approach that supports custom strides and even a self-labeling
+function. What that means, and how that works will be discussed
+in the next section.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/introduction/gettingstarted.rst
+++ b/docs/introduction/gettingstarted.rst
@@ -400,8 +400,7 @@ into or iterated over.
 
 Similarly, the function :func:`batchview` creates a decorator
 that makes the given data container appear as a vector of equally
-sized mini-batches. For more information take a look at the
-section on :ref:`dataviews`.
+sized mini-batches.
 
 .. code-block:: jlcon
 
@@ -410,6 +409,43 @@ section on :ref:`dataviews`.
     [0.226582 0.933372; 0.504629 0.522172]
     [0.505208 0.0443222; 0.0997825 0.722906]
     [0.812814 0.11202; 0.245457 0.000341996]
+
+A third but conceptually different kind of view is provided by
+:func:`slidingwindow`. This function is particularly useful for
+preparing sequence data for various training tasks. For more
+information take a look at the section on :ref:`dataviews`.
+
+.. code-block:: jlcon
+
+   julia> data = split("The quick brown fox jumps over the lazy dog")
+   9-element Array{SubString{String},1}:
+    "The"
+    "quick"
+    "brown"
+    "fox"
+    "jumps"
+    "over"
+    "the"
+    "lazy"
+    "dog"
+
+   julia> A = slidingwindow(i->i+2, data, 2, stride=1)
+   7-element slidingwindow(::##9#10, ::Array{SubString{String},1}, 2, stride = 1) with element type Tuple{...}:
+    (["The", "quick"], "brown")
+    (["quick", "brown"], "fox")
+    (["brown", "fox"], "jumps")
+    (["fox", "jumps"], "over")
+    (["jumps", "over"], "the")
+    (["over", "the"], "lazy")
+    (["the", "lazy"], "dog")
+
+   julia> A = slidingwindow(i->[i-2:i-1; i+1:i+2], data, 1)
+   5-element slidingwindow(::##11#12, ::Array{SubString{String},1}, 1) with element type Tuple{...}:
+    (["brown"], ["The", "quick", "fox", "jumps"])
+    (["fox"], ["quick", "brown", "jumps", "over"])
+    (["jumps"], ["brown", "fox", "over", "the"])
+    (["over"], ["fox", "jumps", "the", "lazy"])
+    (["the"], ["jumps", "over", "lazy", "dog"])
 
 Aside from data containers, there is also another sub-category of
 data sources, called **data iterators**, that can not be indexed
@@ -514,6 +550,8 @@ package can be utilized to solve them.
 - :ref:`Repartition a data container using a k-folds scheme. <k_folds>`
 
 - :ref:`Iterate over my data one observation or batch at a time. <dataviews>`
+
+- :ref:`Prepare sequence data such as text for supervised learning. <sequences>`
 
 Getting Help
 -------------

--- a/src/MLDataPattern.jl
+++ b/src/MLDataPattern.jl
@@ -34,6 +34,9 @@ export
     batchview,
     batchsize,
 
+    SlidingWindow,
+    slidingwindow,
+
     targets,
     eachtarget,
 
@@ -54,10 +57,10 @@ export
     eachobs,
     eachbatch
 
-obsdim_string(::ObsDim.First) = "first"
-obsdim_string(::ObsDim.Last) = "last"
+obsdim_string(::ObsDim.First) = ":first"
+obsdim_string(::ObsDim.Last) = ":last"
 obsdim_string(::ObsDim.Constant{D}) where {D} = string(D)
-obsdim_string(::ObsDim.Undefined) = "NA"
+obsdim_string(::ObsDim.Undefined) = "\"NA\""
 obsdim_string(obsdim::Tuple) = string("(", join(map(obsdim_string, obsdim), ", "), ")")
 
 include("container.jl")
@@ -66,6 +69,7 @@ include("randobs.jl")
 include("shuffleobs.jl")
 include("splitobs.jl")
 include("dataview.jl")
+include("slidingwindow.jl")
 include("targets.jl")
 include("stratifiedobs.jl")
 include("resample.jl")

--- a/src/container.jl
+++ b/src/container.jl
@@ -28,6 +28,11 @@ _view(indices::Range, i::Range) = indices[i]
 _view(indices, i::Int) = indices[i] # to throw error in case
 _view(indices, i) = view(indices, i)
 
+# can be used to prevent specific data container to be used
+# in (specific) functions. For example passing a BatchView to
+# oversample or undersample should throw an error
+allowcontainer(fun, data) = true
+
 """
     nobs(data, [obsdim]) -> Int
 

--- a/src/dataview.jl
+++ b/src/dataview.jl
@@ -3,7 +3,7 @@ Base.size(A::DataView) = (length(A),)
 Base.endof(A::DataView) = length(A)
 getobs(A::DataView) = getobs.(A)
 getobs(A::DataView, i) = getobs(A[i])
-getobs{T<:Tuple}(A::DataView{T}) = map(x->getobs.(x), A)
+getobs{T<:Tuple}(A::DataView{T}) = map(i->getobs(A,i), 1:length(A))
 getobs{T<:Tuple}(A::DataView{T}, i::Integer) = getobs.(A[i])
 
 # for proper dispatch to trump the abstract arrays one

--- a/src/dataview.jl
+++ b/src/dataview.jl
@@ -420,7 +420,7 @@ Base.summary(A::BatchView) = summary_build(A)
 
 # if subsetting a DataView, then DataView the subset instead.
 for fun in (:DataSubset, :datasubset), O in (ObsDimension, Tuple)
-    @eval @generated function ($fun){T<:DataView}(A::T, i, obsdim::$O)
+    @eval @generated function ($fun){T<:AbstractObsView}(A::T, i, obsdim::$O)
         quote
             @assert obsdim == A.obsdim
             ($(T.name.name))(($($fun))(parent(A), i, obsdim), obsdim)

--- a/src/dataview.jl
+++ b/src/dataview.jl
@@ -6,6 +6,9 @@ getobs(A::DataView, i) = getobs(A[i])
 getobs{T<:Tuple}(A::DataView{T}) = map(i->getobs(A,i), 1:length(A))
 getobs{T<:Tuple}(A::DataView{T}, i::Integer) = getobs.(A[i])
 
+allowcontainer(fun, ::AbstractObsView) = true
+allowcontainer(fun, ::DataView) = false
+
 # for proper dispatch to trump the abstract arrays one
 for T in (ObsDim.Constant, ObsDim.Last, Tuple)
     @eval function nobs(A::DataView, obsdim::$T)
@@ -381,6 +384,9 @@ function BatchView(data; size = -1, maxsize = -1, count = -1, obsdim = default_o
         BatchView(data, size, count, convert(LearnBase.ObsDimension,obsdim))
     end
 end
+
+allowcontainer(::typeof(shuffleobs), ::BatchView) = true
+allowcontainer(::typeof(splitobs), ::BatchView) = true
 
 """
     batchsize(data) -> Int

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -91,6 +91,7 @@ oversample(f, data; shuffle=true, obsdim=default_obsdim(data)) =
     oversample(f, data, shuffle, convert(LearnBase.ObsDimension,obsdim))
 
 function oversample(f, data, shuffle::Bool, obsdim=default_obsdim(data))
+    allowcontainer(oversample, data) || throw(MethodError(oversample, (f,data,shuffle,obsdim)))
     lm = labelmap(eachtarget(f, data, obsdim))
     maxcount = maximum(length, values(lm))
 
@@ -199,6 +200,7 @@ undersample(f, data; shuffle=false, obsdim=default_obsdim(data)) =
     undersample(f, data, shuffle, convert(LearnBase.ObsDimension,obsdim))
 
 function undersample(f, data, shuffle::Bool, obsdim=default_obsdim(data))
+    allowcontainer(undersample, data) || throw(MethodError(undersample, (f,data,shuffle,obsdim)))
     lm = labelmap(eachtarget(f, data, obsdim))
     mincount = minimum(length, values(lm))
 

--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -31,5 +31,6 @@ shuffleobs(data; obsdim = default_obsdim(data)) =
     shuffleobs(data, convert(LearnBase.ObsDimension,obsdim))
 
 function shuffleobs(data, obsdim)
+    allowcontainer(shuffleobs, data) || throw(MethodError(shuffleobs, (data,obsdim)))
     datasubset(data, randperm(nobs(data, obsdim)), obsdim)
 end

--- a/src/slidingwindow.jl
+++ b/src/slidingwindow.jl
@@ -1,40 +1,11 @@
-struct SlidingWindow{TElem,TData,O,TFun} <: LearnBase.DataView{TElem,TData}
-    data::TData
-    targetfun::TFun
-    size::Int
-    stride::Int
-    count::Int
-    obsdim::O
-end
-
-const UnlabeledSlidingWindow{TElem,TData,O} = SlidingWindow{TElem,TData,O,Void}
-
-function slidingwindow(data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {T,O}
-    E = typeof(datasubset(data,1:1+size,obsdim))
-    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
-    SlidingWindow{E,T,O,Void}(data, nothing, size, stride, count, obsdim)
-end
-
-function slidingwindow(f::F, data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {F,T,O}
-    E = typeof((datasubset(data,1:1+size,obsdim),datasubset(data,f(1),obsdim)))
-    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
-    offset = 1 + (count-1) * stride
-    while maximum(f(offset)) > nobs(data)
-        count -= 1
-        offset = 1 + (count-1) * stride
-    end
-    SlidingWindow{E,T,O,F}(data, f, size, stride, count, obsdim)
-end
-
-slidingwindow(data, size::Int; stride=size, obsdim=default_obsdim(data)) =
-    slidingwindow(data, size, stride, convert(LearnBase.ObsDimension, obsdim))
-
-slidingwindow(f, data, size::Int; stride=size, obsdim=default_obsdim(data)) =
-    slidingwindow(f, data, size, stride, convert(LearnBase.ObsDimension, obsdim))
+abstract type SlidingWindow{TElem,TData,O} <: DataView{TElem,TData} end
 
 Base.parent(A::SlidingWindow) = A.data
 Base.length(A::SlidingWindow) = nobs(A)
 nobs(A::SlidingWindow) = A.count
+
+# compatibility with nested functions
+default_obsdim(A::SlidingWindow) = A.obsdim
 
 function _windowsettings(A::SlidingWindow, windowindex::Int)
     offset = 1 + (windowindex-1) * A.stride
@@ -42,24 +13,138 @@ function _windowsettings(A::SlidingWindow, windowindex::Int)
     offset, range
 end
 
+# --------------------------------------------------------------------
+
+const WindowBatchView{TElem,O} = BatchView{TElem,<:SlidingWindow,O}
+
+function BatchView(data::T, size::Int, count::Int, obsdim::O = default_obsdim(data), upto::Bool = false) where {T<:SlidingWindow,O}
+    nsize, ncount = _compute_batch_settings(data, size, count, obsdim, upto)
+    E = typeof(_getwindowbatch(data, nsize, 1))
+    BatchView{E,T,O}(data, nsize, ncount, obsdim)
+end
+
+function Base.getindex(A::WindowBatchView, batchindex::Int)
+    _getwindowbatch(parent(A), A.size, batchindex)
+end
+
+function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
+    [A[bi] for bi in batchindices]
+end
+
+# --------------------------------------------------------------------
+
+"""
+TODO
+"""
+struct UnlabeledSlidingWindow{TElem,TData,O} <: SlidingWindow{TElem,TData,O}
+    data::TData
+    size::Int
+    stride::Int
+    count::Int
+    obsdim::O
+end
+
+function slidingwindow(data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {T,O}
+    E = typeof(datasubset(data,1:size,obsdim))
+    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
+    UnlabeledSlidingWindow{E,T,O}(data, size, stride, count, obsdim)
+end
+
+function slidingwindow(data, size::Int; stride=size, obsdim=default_obsdim(data))
+    slidingwindow(data, size, stride, convert(LearnBase.ObsDimension, obsdim))
+end
+
 function Base.getindex(A::UnlabeledSlidingWindow, windowindex::Int)
     _, windowrange = _windowsettings(A, windowindex)
     datasubset(A.data, windowrange, A.obsdim)
 end
 
-function Base.getindex(A::SlidingWindow, windowindex::Int)
+# --------------------------------------------------------------------
+
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}) where {T} = map(x->getobs.(x), A)
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::AbstractVector) where {T} = map(x->getobs.(x), A)
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::Int) where {T} = getobs.(A[i])
+
+function _getwindowbatch(W::UnlabeledSlidingWindow, batchsize::Int, batchindex::Int)
+    batchrange = _batchrange(batchsize, batchindex)
+    windowranges = [_windowsettings(W, windowindex)[2] for windowindex in batchrange]
+    [datasubset(W.data, [windowranges[wi][oi] for wi in 1:batchsize], W.obsdim) for oi in 1:W.size]
+end
+
+# --------------------------------------------------------------------
+
+"""
+TODO
+"""
+struct LabeledSlidingWindow{TElem,TData,O,TFun,Exclude} <: SlidingWindow{TElem,TData,O}
+    data::TData
+    targetfun::TFun
+    size::Int
+    stride::Int
+    count::Int
+    offset::Int
+    obsdim::O
+end
+
+function slidingwindow(f::F, data::T, size::Int, stride::Int, ::Type{Val{Exclude}}=Val{false}, obsdim::O = default_obsdim(data)) where {F,T,Exclude,O}
+    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
+    # limit back of sequence until it contains target
+    o = 1 + (count-1) * stride
+    while maximum(f(o)) > nobs(data)
+        count -= 1
+        o = 1 + (count-1) * stride
+    end
+    # limit front of sequence until it contains target
+    offset = 0
+    o = 1 + offset * stride
+    while minimum(f(o)) < 1
+        offset += 1
+        count -= 1
+        o = 1 + offset * stride
+    end
+    # construct view
+    E = typeof((datasubset(data,o:o+size-1,obsdim),datasubset(data,f(o),obsdim)))
+    LabeledSlidingWindow{E,T,O,F,Exclude}(data, f, size, stride, count, offset, obsdim)
+end
+
+function slidingwindow(f, data, size::Int; stride=size, excludetarget=false, obsdim=default_obsdim(data))
+    slidingwindow(f, data, size, stride, Val{excludetarget}, convert(LearnBase.ObsDimension, obsdim))
+end
+
+function Base.getindex(A::LabeledSlidingWindow{TElem,TData,O,TFun,Exclude}, wi::Int) where {TElem,TData,O,TFun,Exclude}
+    windowindex = wi + A.offset
     offset, windowrange = _windowsettings(A, windowindex)
-    X = datasubset(A.data, windowrange, A.obsdim)
+    windowindices = if Exclude
+        setdiff(windowrange, A.targetfun(offset))
+    else
+        windowrange
+    end
+    X = datasubset(A.data, windowindices, A.obsdim)
     Y = datasubset(A.data, A.targetfun(offset), A.obsdim)
     X, Y
 end
 
-# compatibility with nested functions
-default_obsdim(A::SlidingWindow) = A.obsdim
+# --------------------------------------------------------------------
+
+function _getwindowbatch(A::LabeledSlidingWindow{TElem,TData,O,TFun,Exclude}, batchsize::Int, batchindex::Int) where {TElem,TData,O,TFun,Exclude}
+    batchrange = _batchrange(batchsize, batchindex)
+    fltr = if Exclude
+        s -> (A.targetfun(s[1]), setdiff(s[2], A.targetfun(s[1])))
+    else
+        s -> (A.targetfun(s[1]), s[2])
+    end
+    windowsettings = [fltr(_windowsettings(A, windowindex)) for windowindex in batchrange]
+    ([datasubset(A.data, [windowsettings[wi][2][oi] for wi in 1:batchsize], A.obsdim)
+        for oi in 1:length(windowsettings[1][2])],
+     [datasubset(A.data, [windowsettings[wi][1][oi] for wi in 1:batchsize], A.obsdim)
+        for oi in 1:length(windowsettings[1][1])])
+end
+
+# --------------------------------------------------------------------
 
 function ShowItLikeYouBuildIt.showarg(io::IO, A::SlidingWindow)
     print(io, "slidingwindow(")
-    if A.targetfun != nothing
+    if A isa LabeledSlidingWindow
         showarg(io, A.targetfun)
         print(io, ", ")
     end
@@ -78,23 +163,3 @@ function ShowItLikeYouBuildIt.showarg(io::IO, A::SlidingWindow)
 end
 
 Base.summary(A::SlidingWindow) = summary_build(A)
-
-const WindowBatchView{TElem,O} = BatchView{TElem,<:SlidingWindow,O}
-const UnlabeledWindowBatchView{TElem,O} = BatchView{TElem,<:UnlabeledSlidingWindow,O}
-
-function BatchView(data::T, size::Int, count::Int, obsdim::O = default_obsdim(data), upto::Bool = false) where {T<:SlidingWindow,O}
-    nsize, ncount = _compute_batch_settings(data, size, count, obsdim, upto)
-    E = Any
-    BatchView{E,T,O}(data, nsize, ncount, obsdim)
-end
-
-function Base.getindex(A::WindowBatchView, batchindex::Int)
-    W = parent(A)
-    batchrange = _batchrange(A.size, batchindex)
-    windowranges = [_windowsettings(W, windowindex)[2] for windowindex in batchrange]
-    [datasubset(W.data, [windowranges[wi][oi] for wi in 1:A.size], W.obsdim) for oi in 1:W.size]
-end
-
-function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
-    [A[bi] for bi in batchindices]
-end

--- a/src/slidingwindow.jl
+++ b/src/slidingwindow.jl
@@ -1,0 +1,100 @@
+struct SlidingWindow{TElem,TData,O,TFun} <: LearnBase.DataView{TElem,TData}
+    data::TData
+    targetfun::TFun
+    size::Int
+    stride::Int
+    count::Int
+    obsdim::O
+end
+
+const UnlabeledSlidingWindow{TElem,TData,O} = SlidingWindow{TElem,TData,O,Void}
+
+function slidingwindow(data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {T,O}
+    E = typeof(datasubset(data,1:1+size,obsdim))
+    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
+    SlidingWindow{E,T,O,Void}(data, nothing, size, stride, count, obsdim)
+end
+
+function slidingwindow(f::F, data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {F,T,O}
+    E = typeof((datasubset(data,1:1+size,obsdim),datasubset(data,f(1),obsdim)))
+    count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
+    offset = 1 + (count-1) * stride
+    while maximum(f(offset)) > nobs(data)
+        count -= 1
+        offset = 1 + (count-1) * stride
+    end
+    SlidingWindow{E,T,O,F}(data, f, size, stride, count, obsdim)
+end
+
+slidingwindow(data, size::Int; stride=size, obsdim=default_obsdim(data)) =
+    slidingwindow(data, size, stride, convert(LearnBase.ObsDimension, obsdim))
+
+slidingwindow(f, data, size::Int; stride=size, obsdim=default_obsdim(data)) =
+    slidingwindow(f, data, size, stride, convert(LearnBase.ObsDimension, obsdim))
+
+Base.parent(A::SlidingWindow) = A.data
+Base.length(A::SlidingWindow) = nobs(A)
+nobs(A::SlidingWindow) = A.count
+
+function _windowsettings(A::SlidingWindow, windowindex::Int)
+    offset = 1 + (windowindex-1) * A.stride
+    range = offset:offset+A.size-1
+    offset, range
+end
+
+function Base.getindex(A::UnlabeledSlidingWindow, windowindex::Int)
+    _, windowrange = _windowsettings(A, windowindex)
+    datasubset(A.data, windowrange, A.obsdim)
+end
+
+function Base.getindex(A::SlidingWindow, windowindex::Int)
+    offset, windowrange = _windowsettings(A, windowindex)
+    X = datasubset(A.data, windowrange, A.obsdim)
+    Y = datasubset(A.data, A.targetfun(offset), A.obsdim)
+    X, Y
+end
+
+# compatibility with nested functions
+default_obsdim(A::SlidingWindow) = A.obsdim
+
+function ShowItLikeYouBuildIt.showarg(io::IO, A::SlidingWindow)
+    print(io, "slidingwindow(")
+    if A.targetfun != nothing
+        showarg(io, A.targetfun)
+        print(io, ", ")
+    end
+    showarg(io, parent(A))
+    print(io, ", ")
+    print(io, A.size)
+    if A.stride != A.size
+        print(io, ", ")
+        print(io, "stride = ", A.stride)
+    end
+    if A.obsdim != default_obsdim(A.data)
+        print(io, ", ")
+        print(io, "obsdim = ", obsdim_string(A.obsdim))
+    end
+    print(io, ')')
+end
+
+Base.summary(A::SlidingWindow) = summary_build(A)
+
+const WindowBatchView{TElem,O} = BatchView{TElem,<:SlidingWindow,O}
+const UnlabeledWindowBatchView{TElem,O} = BatchView{TElem,<:UnlabeledSlidingWindow,O}
+
+function BatchView(data::T, size::Int, count::Int, obsdim::O = default_obsdim(data), upto::Bool = false) where {T<:SlidingWindow,O}
+    nsize, ncount = _compute_batch_settings(data, size, count, obsdim, upto)
+    E = Any
+    BatchView{E,T,O}(data, nsize, ncount, obsdim)
+end
+
+function Base.getindex(A::WindowBatchView, batchindex::Int)
+    W = parent(A)
+    batchrange = _batchrange(A.size, batchindex)
+    windowranges = [_windowsettings(W, windowindex)[2] for windowindex in batchrange]
+    [datasubset(W.data, [windowranges[wi][oi] for wi in 1:A.size], W.obsdim) for oi in 1:W.size]
+end
+
+function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
+    [A[bi] for bi in batchindices]
+end

--- a/src/slidingwindow.jl
+++ b/src/slidingwindow.jl
@@ -21,27 +21,6 @@ end
 
 # --------------------------------------------------------------------
 
-const WindowBatchView{TElem,O} = BatchView{TElem,<:SlidingWindow,O}
-
-function BatchView(data::T, size::Int, count::Int, obsdim::O = default_obsdim(data), upto::Bool = false) where {T<:SlidingWindow,O}
-    nsize, ncount = _compute_batch_settings(data, size, count, obsdim, upto)
-    E = typeof(_getwindowbatch(data, nsize, 1))
-    BatchView{E,T,O}(data, nsize, ncount, obsdim)
-end
-
-function Base.getindex(A::WindowBatchView, batchindex::Int)
-    _getwindowbatch(parent(A), A.size, batchindex)
-end
-
-function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
-    [A[bi] for bi in batchindices]
-end
-
-# --------------------------------------------------------------------
-
-"""
-TODO
-"""
 struct UnlabeledSlidingWindow{TElem,TData,O} <: SlidingWindow{TElem,TData,O}
     data::TData
     size::Int
@@ -50,6 +29,11 @@ struct UnlabeledSlidingWindow{TElem,TData,O} <: SlidingWindow{TElem,TData,O}
     obsdim::O
 end
 
+"""
+    slidingwindow(data, size, [stride], [obsdim]) -> UnlabeledSlidingWindow
+
+TODO
+"""
 function slidingwindow(data::T, size::Int, stride::Int, obsdim::O = default_obsdim(data)) where {T,O}
     _check_windowargs(data, size, stride, obsdim)
     E = typeof(datasubset(data,1:size,obsdim))
@@ -75,21 +59,6 @@ getobs(A::UnlabeledSlidingWindow, indices::AbstractVector) = [getobs(A,i) for i 
 
 # --------------------------------------------------------------------
 
-getobs(A::BatchView{T,<:UnlabeledSlidingWindow}) where {T} = map(x->getobs.(x), A)
-getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::AbstractVector) where {T} = map(x->getobs.(x), A)
-getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::Int) where {T} = getobs.(A[i])
-
-function _getwindowbatch(W::UnlabeledSlidingWindow, batchsize::Int, batchindex::Int)
-    batchrange = _batchrange(batchsize, batchindex)
-    windowranges = [_windowsettings(W, windowindex)[2] for windowindex in batchrange]
-    [datasubset(W.data, [windowranges[wi][oi] for wi in 1:batchsize], W.obsdim) for oi in 1:W.size]
-end
-
-# --------------------------------------------------------------------
-
-"""
-TODO
-"""
 struct LabeledSlidingWindow{TElem,TData,O,TFun,Exclude} <: SlidingWindow{TElem,TData,O}
     data::TData
     targetfun::TFun
@@ -100,6 +69,11 @@ struct LabeledSlidingWindow{TElem,TData,O,TFun,Exclude} <: SlidingWindow{TElem,T
     obsdim::O
 end
 
+"""
+    slidingwindow(f, data, size, [stride], [excludetarget], [obsdim]) -> LabeledSlidingWindow
+
+TODO
+"""
 function slidingwindow(f::F, data::T, size::Int, stride::Int, ::Type{Val{Exclude}}=Val{false}, obsdim::O = default_obsdim(data)) where {F,T,Exclude,O}
     _check_windowargs(data, size, stride, obsdim)
     count = floor(Int, (nobs(data,obsdim) - size + stride) / stride)
@@ -163,22 +137,6 @@ end
 
 # --------------------------------------------------------------------
 
-function _getwindowbatch(A::LabeledSlidingWindow{TElem,TData,O,TFun,Exclude}, batchsize::Int, batchindex::Int) where {TElem,TData,O,TFun,Exclude}
-    batchrange = _batchrange(batchsize, batchindex)
-    fltr = if Exclude
-        s -> (A.targetfun(s[1]), setdiff(s[2], A.targetfun(s[1])))
-    else
-        s -> (A.targetfun(s[1]), s[2])
-    end
-    windowsettings = [fltr(_windowsettings(A, windowindex)) for windowindex in batchrange]
-    ([datasubset(A.data, [windowsettings[wi][2][oi] for wi in 1:batchsize], A.obsdim)
-        for oi in 1:length(windowsettings[1][2])],
-     [datasubset(A.data, [windowsettings[wi][1][oi] for wi in 1:batchsize], A.obsdim)
-        for oi in 1:length(windowsettings[1][1])])
-end
-
-# --------------------------------------------------------------------
-
 function ShowItLikeYouBuildIt.showarg(io::IO, A::SlidingWindow)
     print(io, "slidingwindow(")
     if A isa LabeledSlidingWindow
@@ -200,3 +158,50 @@ function ShowItLikeYouBuildIt.showarg(io::IO, A::SlidingWindow)
 end
 
 Base.summary(A::SlidingWindow) = summary_build(A)
+
+# --------------------------------------------------------------------
+# batches of sliding windows
+
+const WindowBatchView{TElem,O} = BatchView{TElem,<:SlidingWindow,O}
+
+function BatchView(data::T, size::Int, count::Int, obsdim::O = default_obsdim(data), upto::Bool = false) where {T<:SlidingWindow,O}
+    nsize, ncount = _compute_batch_settings(data, size, count, obsdim, upto)
+    E = typeof(_getwindowbatch(data, nsize, 1))
+    BatchView{E,T,O}(data, nsize, ncount, obsdim)
+end
+
+function Base.getindex(A::WindowBatchView, batchindex::Int)
+    _getwindowbatch(parent(A), A.size, batchindex)
+end
+
+function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
+    [A[bi] for bi in batchindices]
+end
+
+# --------------------------------------------------------------------
+
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}) where {T} = map(x->getobs.(x), A)
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::AbstractVector) where {T} = map(x->getobs.(x), A)
+getobs(A::BatchView{T,<:UnlabeledSlidingWindow}, i::Int) where {T} = getobs.(A[i])
+
+function _getwindowbatch(W::UnlabeledSlidingWindow, batchsize::Int, batchindex::Int)
+    batchrange = _batchrange(batchsize, batchindex)
+    windowranges = [_windowsettings(W, windowindex)[2] for windowindex in batchrange]
+    [datasubset(W.data, [windowranges[wi][oi] for wi in 1:batchsize], W.obsdim) for oi in 1:W.size]
+end
+
+# --------------------------------------------------------------------
+
+function _getwindowbatch(A::LabeledSlidingWindow{TElem,TData,O,TFun,Exclude}, batchsize::Int, batchindex::Int) where {TElem,TData,O,TFun,Exclude}
+    batchrange = _batchrange(batchsize, batchindex)
+    fltr = if Exclude
+        s -> (A.targetfun(s[1]), setdiff(s[2], A.targetfun(s[1])))
+    else
+        s -> (A.targetfun(s[1]), s[2])
+    end
+    windowsettings = [fltr(_windowsettings(A, windowindex)) for windowindex in batchrange]
+    ([datasubset(A.data, [windowsettings[wi][2][oi] for wi in 1:batchsize], A.obsdim)
+        for oi in 1:length(windowsettings[1][2])],
+     [datasubset(A.data, [windowsettings[wi][1][oi] for wi in 1:batchsize], A.obsdim)
+        for oi in 1:length(windowsettings[1][1])])
+end

--- a/src/slidingwindow.jl
+++ b/src/slidingwindow.jl
@@ -4,6 +4,8 @@ Base.parent(A::SlidingWindow) = A.data
 Base.length(A::SlidingWindow) = nobs(A)
 nobs(A::SlidingWindow) = A.count
 
+allowcontainer(fun, ::SlidingWindow) = true
+
 # compatibility with nested functions
 default_obsdim(A::SlidingWindow) = A.obsdim
 
@@ -301,6 +303,11 @@ end
 function Base.getindex(A::WindowBatchView, batchindices::AbstractVector)
     [A[bi] for bi in batchindices]
 end
+
+# shuffling/resampling like this is broken
+allowcontainer(fun, ::BatchView{<:Any,<:SlidingWindow}) = false
+allowcontainer(::typeof(shuffleobs), ::BatchView{<:Any,<:SlidingWindow}) = false
+allowcontainer(::typeof(splitobs), ::BatchView{<:Any,<:SlidingWindow}) = false
 
 # --------------------------------------------------------------------
 

--- a/src/splitobs.jl
+++ b/src/splitobs.jl
@@ -115,13 +115,15 @@ splitobs(data; at = 0.7, obsdim = default_obsdim(data)) =
 
 # partition into 2 sets
 function splitobs(data, at::AbstractFloat, obsdim=default_obsdim(data))
+    allowcontainer(splitobs, data) || throw(MethodError(splitobs, (data,at,obsdim)))
     n = nobs(data, obsdim)
     idx1, idx2 = splitobs(n, at)
     datasubset(data, idx1, obsdim), datasubset(data, idx2, obsdim)
 end
 
 # partition into length(at)+1 sets
-function splitobs{N}(data, at::NTuple{N,AbstractFloat}, obsdim=default_obsdim(data))
+function splitobs(data, at::NTuple{N,AbstractFloat}, obsdim=default_obsdim(data)) where N
+    allowcontainer(splitobs, data) || throw(MethodError(splitobs, (data,at,obsdim)))
     n = nobs(data, obsdim)
     map(idx->datasubset(data, idx, obsdim), splitobs(n, at))
 end

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -193,6 +193,9 @@ function stratifiedobs(f, data, p::Union{NTuple,AbstractFloat}, shuffle::Bool = 
     # The given data is always shuffled to qualify as performing
     # stratified sampling without replacement.
     data_shuf = shuffleobs(data, obsdim)
+    # FIXME: if i put the following line before `data_shuf` is
+    #        defined, it breaks type inference for `data_shuf`.
+    allowcontainer(stratifiedobs, data) || throw(MethodError(stratifiedobs, (f,data,shuffle,obsdim)))
     idx_tup = splitobs(labelmap(eachtarget(f, data_shuf, obsdim)), p)
     # Setting the parameter "shuffle = false" specifies that the
     # classes are ordered in the resulting subsets respectively.

--- a/test/references/FoldsView.txt
+++ b/test/references/FoldsView.txt
@@ -2,4 +2,4 @@
   data: 10-element Array{Float64,1}
   training: 8 observations/fold
   validation: 2 observations/fold
-  obsdim: last
+  obsdim: :last

--- a/test/references/labeledslidingwindow.txt
+++ b/test/references/labeledslidingwindow.txt
@@ -1,0 +1,3 @@
+2-element slidingwindow(::Base.#identity, ::UnitRange{Int64}, 3, stride = 2) with element type Tuple{SubArray{Int64,1,UnitRange{Int64},Tuple{UnitRange{Int64}},true},SubArray{Int64,0,UnitRange{Int64},Tuple{Int64},false}}:
+ ([1, 2, 3], 1)
+ ([3, 4, 5], 3)

--- a/test/references/labeledslidingwindow.txt
+++ b/test/references/labeledslidingwindow.txt
@@ -1,3 +1,3 @@
-2-element slidingwindow(::Base.#identity, ::UnitRange{Int64}, 3, stride = 2) with element type Tuple{SubArray{Int64,1,UnitRange{Int64},Tuple{UnitRange{Int64}},true},SubArray{Int64,0,UnitRange{Int64},Tuple{Int64},false}}:
+2-element slidingwindow(::Base.#identity, ::UnitRange{Int64}, 3, stride = 2, obsdim = :first) with element type Tuple{SubArray{Int64,1,UnitRange{Int64},Tuple{UnitRange{Int64}},true},SubArray{Int64,0,UnitRange{Int64},Tuple{Int64},false}}:
  ([1, 2, 3], 1)
  ([3, 4, 5], 3)

--- a/test/references/unlabeledslidingwindow.txt
+++ b/test/references/unlabeledslidingwindow.txt
@@ -1,0 +1,3 @@
+2-element slidingwindow(::UnitRange{Int64}, 3, stride = 2) with element type SubArray{Int64,1,UnitRange{Int64},Tuple{UnitRange{Int64}},true}:
+ [1, 2, 3]
+ [3, 4, 5]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,7 @@ tests = [
     "tst_shuffleobs.jl"
     "tst_splitobs.jl"
     "tst_dataview.jl"
+    "tst_slidingwindow.jl"
     "tst_targets.jl"
     "tst_stratifiedobs.jl"
     "tst_resample.jl"

--- a/test/tst_dataview.jl
+++ b/test/tst_dataview.jl
@@ -177,6 +177,9 @@ end
     @test BatchView <: AbstractBatchIterator
     @test BatchView <: AbstractDataIterator
     @test batchview == BatchView
+    @test_throws MethodError oversample(BatchView(X))
+    @test_throws MethodError undersample(BatchView(X))
+    @test_throws MethodError stratifiedobs(BatchView(X))
 
     @testset "constructor" begin
         @test_throws DimensionMismatch BatchView((rand(2,10),rand(9)))

--- a/test/tst_dataview.jl
+++ b/test/tst_dataview.jl
@@ -8,7 +8,6 @@
 
     @testset "constructor" begin
         @test_throws DimensionMismatch ObsView((rand(2,10),rand(9)))
-        @test_throws DimensionMismatch ObsView((rand(2,10),rand(9)))
         @test_throws DimensionMismatch ObsView((rand(2,10),rand(4,9,10),rand(9)))
         @test_throws MethodError ObsView(EmptyType())
         @test_throws MethodError ObsView(EmptyType(), ObsDim.Last())

--- a/test/tst_folds.jl
+++ b/test/tst_folds.jl
@@ -1,3 +1,9 @@
+@test_throws MethodError shuffleobs(kfolds(X1))
+@test_throws MethodError splitobs(kfolds(X1))
+@test_throws MethodError oversample(kfolds(X1))
+@test_throws MethodError undersample(kfolds(X1))
+@test_throws MethodError stratifiedobs(kfolds(X1))
+
 @testset "kfolds with Int" begin
     @test typeof(kfolds) <: Function
     @test typeof(kfolds(10)) <: Tuple

--- a/test/tst_resample.jl
+++ b/test/tst_resample.jl
@@ -74,8 +74,19 @@ lett = ["a","b","b","c","c","c","d","d","d","d","d"]
         src = rand([1, 2,2, 3,3,3, 4,4,4,4], n_src)
         oversampled = oversample(src)
         @test all(counts(oversampled).==counts(oversampled)[1])
-        @test all( x ∈ oversampled for x in unique(src))
+        @test all(x ∈ oversampled for x in unique(src))
         @test length(oversampled) > n_src
+    end
+
+    @testset "ObsView" begin
+        n_src = 200
+        src = rand([1, 2,2, 3,3,3, 4,4,4,4], n_src)
+        src2 = obsview(src)
+        @test typeof(src2) <: ObsView
+        oversampled2 = getobs.(@inferred(oversample(src2)))
+        @test all(counts(oversampled2).==counts(oversampled2)[1])
+        @test all(x ∈ oversampled2 for x in unique(src))
+        @test length(oversampled2) > n_src
     end
 
     @testset "Advanced" begin
@@ -87,7 +98,7 @@ lett = ["a","b","b","c","c","c","d","d","d","d","d"]
 
         data_os, lbls_os = oversample((data, lbs); obsdim=od)
         @test all(counts(lbls_os).==counts(lbls_os)[1])
-        @test all( x ∈ lbls_os for x in unique(lbls_os))
+        @test all(x ∈ lbls_os for x in unique(lbls_os))
         @test nobs(data_os, ObsDim.First()) == nobs(lbls_os)
         @test nobs(lbls_os) > n_src
     end
@@ -188,6 +199,17 @@ end
         n_src = 2000
         src = rand([1, 2,2, 3,3,3, 4,4,4,4], n_src)
         sampled = undersample(src)
+        @test all(counts(sampled).==counts(sampled)[1])
+        @test all( x ∈ sampled for x in unique(src))
+        @test length(sampled) < n_src
+    end
+
+    @testset "ObsView" begin
+        n_src = 200
+        src = rand([1, 2,2, 3,3,3, 4,4,4,4], n_src)
+        src2 = obsview(src)
+        @test typeof(src2) <: ObsView
+        sampled = getobs.(@inferred(undersample(src2)))
         @test all(counts(sampled).==counts(sampled)[1])
         @test all( x ∈ sampled for x in unique(src))
         @test length(sampled) < n_src

--- a/test/tst_shuffleobs.jl
+++ b/test/tst_shuffleobs.jl
@@ -84,3 +84,30 @@ end
     @test sum(y1) == 11325
     @test all(x1 .== y1)
 end
+
+@testset "ObsView" begin
+    # tests if all obs are still present and none duplicated
+    ov = @inferred shuffleobs(obsview(X1))
+    @test ov isa ObsView
+    x1 = getobs(ov)
+    @test sum(x1) == fill(11325,10)
+    # also tests that both paramter are shuffled identically
+    ov = @inferred shuffleobs(obsview((X1,X1)))
+    @test ov isa ObsView
+    x1 = getobs(ov)
+    for i = 1:length(x1)
+        @test x1[i][1] == x1[i][2]
+    end
+    for i = 1:2
+        @test sum(getindex.(x1,i)) == fill(11325,10)
+    end
+end
+
+@testset "BatchView" begin
+    # tests if all obs are still present and none duplicated
+    bv1 = batchview(X1, 30)
+    bv = @inferred shuffleobs(bv1)
+    @test length(bv) == length(bv1)
+    @test bv isa BatchView{<:SubArray,<:SubArray}
+    @test vec(sum(sum(bv),2)) == fill(11325,10)
+end

--- a/test/tst_slidingwindow.jl
+++ b/test/tst_slidingwindow.jl
@@ -118,6 +118,34 @@
 
     println("<HEARTBEAT>")
 
+    @testset "batchview" begin
+        bv = batchview(slidingwindow(1:100, 5))
+        @test_throws MethodError shuffleobs(bv)
+        @test_throws MethodError splitobs(bv)
+        @test_throws MethodError oversample(bv)
+        @test_throws MethodError undersample(bv)
+        @test_throws MethodError stratifiedobs(bv)
+        for var in vars # (vars..., tuples..., Xs, ys)
+            A = slidingwindow(var, 5)
+            bv = @inferred batchview(A, 2)
+            go = @inferred getobs(bv)
+            @test go isa Array
+            @test go == bv
+            @test length(bv) == length(A) / 2
+            @test eltype(bv) <: Array{<:SubArray}
+            bs = @inferred bv[1]
+            @test length(bs) == 5
+            @test all(nobs.(bs) .== 2)
+        end
+        A = batchview(slidingwindow(1:20, 2), 5)
+        @test length(A) == 2
+        @test A[1] == [[1,3,5,7,9],[2,4,6,8,10]]
+        @test A[2] == [[11,13,15,17,19],[12,14,16,18,20]]
+        @test A[1] isa Array
+    end
+
+    println("<HEARTBEAT>")
+
     @testset "special values" begin
         A = @inferred slidingwindow(1:10, 2)
         @test length(A) == 5

--- a/test/tst_slidingwindow.jl
+++ b/test/tst_slidingwindow.jl
@@ -1,0 +1,262 @@
+@testset "UnlabeledSlidingWindow" begin
+    @test_throws UndefVarError UnlabeledSlidingWindow
+    @test MLDataPattern.UnlabeledSlidingWindow <: AbstractVector
+    @test MLDataPattern.UnlabeledSlidingWindow <: DataView
+    @test !(MLDataPattern.UnlabeledSlidingWindow <: AbstractObsIterator)
+    @test !(MLDataPattern.UnlabeledSlidingWindow <: AbstractBatchIterator)
+
+    @testset "constructor" begin
+        @test_throws DimensionMismatch slidingwindow((rand(2,10),rand(9)), 1)
+        @test_throws DimensionMismatch slidingwindow((rand(2,10),rand(4,9,10),rand(9)), 1)
+        @test_throws MethodError slidingwindow(EmptyType(), 1)
+        @test_throws MethodError slidingwindow(EmptyType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow(EmptyType(), 1, ObsDim.Undefined())
+        @test_throws MethodError slidingwindow(EmptyType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow((EmptyType(),EmptyType()))
+        @test_throws MethodError slidingwindow(CustomType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow(EmptyType(), 1, obsdim=1)
+        @test_throws MethodError slidingwindow((EmptyType(),EmptyType()), 1)
+
+        for var in (vars..., tuples..., Xs, ys)
+            @test_throws MethodError slidingwindow(var...)
+            @test_throws MethodError slidingwindow(var..., 1)
+            @test_throws MethodError slidingwindow(var..., obsdim=:last)
+            @test_throws MethodError slidingwindow(var..., 1, obsdim=:last)
+            @test_throws ArgumentError slidingwindow(var, 151)
+            @test_throws ArgumentError slidingwindow(var, 0)
+            @test_throws ArgumentError slidingwindow(var, 1, 0)
+            A = @inferred slidingwindow(var, 5, 6)
+            @test A == slidingwindow(var, 5, stride = 6)
+            @test @inferred(length(A)) == A.count == 25
+            @test A.size == 5
+            @test A.stride == 6
+            @test A.obsdim == LearnBase.default_obsdim(var)
+            @test @inferred(nobs(A)) == length(A)
+            @test @inferred(parent(A)) === var
+            A = @inferred(slidingwindow(var, 4))
+            @test A == slidingwindow(var, 4, stride = 4)
+            @test length(A) == A.count == 37
+            @test A.size == 4
+            @test A.stride == 4
+            @test A.obsdim == LearnBase.default_obsdim(var)
+            @test nobs(A) == length(A)
+            @test @inferred(parent(A)) === var
+        end
+        @test slidingwindow((X,X), 5) == @inferred(slidingwindow((X,X), 5, (ObsDim.Last(),ObsDim.Last())))
+        @test slidingwindow((X,X), 5) == @inferred(slidingwindow((X,X), 5, 5, (ObsDim.Last(),ObsDim.Last())))
+        if Int == Int64
+            @test_reference "references/unlabeledslidingwindow.txt" @io2str show(::IO, MIME"text/plain"(), slidingwindow(1:6, 3, 2))
+        end
+        A = slidingwindow(X',5,obsdim=1)
+        @test A == @inferred(slidingwindow(X',5,ObsDim.First()))
+        @test A == @inferred(slidingwindow(X',5,5,ObsDim.First()))
+        @test A == slidingwindow(X',5,obsdim=:first)
+        @test A == slidingwindow(X',5,stride=5,obsdim=:first)
+    end
+
+    println("<HEARTBEAT>")
+
+    @testset "typestability" begin
+        @test_throws ErrorException @inferred(slidingwindow(X, 5, obsdim=2))
+        for var in (vars..., tuples..., Xs, ys)
+            @test typeof(@inferred(slidingwindow(var, 5))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(var, 5, 3))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(var, 5, ObsDim.Last()))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(var, 5, 3, ObsDim.Last()))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(var, 5))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test_throws ErrorException @inferred(slidingwindow(var, 5, obsdim=:last))
+        end
+        for tup in tuples
+            @test typeof(@inferred(slidingwindow(tup,5,(fill(ObsDim.Last(),length(tup))...)))) <: MLDataPattern.UnlabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(tup,5,3,(fill(ObsDim.Last(),length(tup))...)))) <: MLDataPattern.UnlabeledSlidingWindow
+        end
+        @test typeof(@inferred(slidingwindow(CustomType(),5))) <: MLDataPattern.UnlabeledSlidingWindow
+        @test typeof(@inferred(slidingwindow(CustomType(), 5, ObsDim.Undefined()))) <: MLDataPattern.UnlabeledSlidingWindow
+    end
+
+    println("<HEARTBEAT>")
+
+    @testset "AbstractArray interface" begin
+        for var in (vars..., tuples..., Xs, ys)
+            A = slidingwindow(var, 5)
+            @test_throws BoundsError A[-1]
+            @test_throws BoundsError A[length(A)+1]
+            @test @inferred(nobs(A)) == 30
+            @test @inferred(length(A)) == 30
+            @test @inferred(size(A)) == (30,)
+            @test @inferred(A[2:3]) == [datasubset(var,(1*5+1):(2*5)), datasubset(var,(2*5+1):(3*5))]
+            @test eltype(A[2:3]) == typeof(datasubset(var,(1*5+1):(2*5)))
+            @test @inferred(A[[1,3]]) == [datasubset(var,(0*5+1):(1*5)), datasubset(var,(2*5+1):(3*5))]
+            @test @inferred(A[1]) == datasubset(var, 1:5)
+            @test @inferred(A[30]) == datasubset(var, (29*5+1):(30*5))
+            @test @inferred(A[30]) == datasubset(var, nobs(var)-4:nobs(var))
+            @test A[end] == A[30]
+            @test @inferred(getobs(A,1)) == getobs(var, 1:5)
+            @test @inferred(getobs(A,2:3)) == [getobs(var,(1*5+1):(2*5)), getobs(var,(2*5+1):(3*5))]
+            if !(var isa Tuple)
+                @test eltype(getobs(A,1)) == eltype(var)
+            end
+            @test typeof(getobs(A,1)) == typeof(getobs(var, 1:5))
+            @test eltype(getobs(A,2:3)) == typeof(getobs(var, 1:5))
+            @test typeof(@inferred(collect(A))) <: Vector
+            # custom stride
+            A = slidingwindow(var, 5, 2)
+            @test_throws BoundsError A[-1]
+            @test_throws BoundsError A[length(A)+1]
+            @test @inferred(nobs(A)) == 73
+            @test @inferred(length(A)) == 73
+            @test @inferred(size(A)) == (73,)
+            @test A[end] == A[73]
+            @test @inferred(getobs(A,1)) == getobs(var, 1:5)
+            @test @inferred(A[2:3]) == [datasubset(var,3:3+4), datasubset(var,5:5+4)]
+            if !(var isa Tuple)
+                @test eltype(getobs(A,1)) == eltype(var)
+            end
+            @test typeof(@inferred(collect(A))) <: Vector
+        end
+    end
+end
+
+@testset "LabeledSlidingWindow" begin
+    @test_throws UndefVarError LabeledSlidingWindow
+    @test MLDataPattern.LabeledSlidingWindow <: AbstractVector
+    @test MLDataPattern.LabeledSlidingWindow <: DataView
+    @test !(MLDataPattern.LabeledSlidingWindow <: AbstractObsIterator)
+    @test !(MLDataPattern.LabeledSlidingWindow <: AbstractBatchIterator)
+
+    @testset "constructor" begin
+        @test_throws DimensionMismatch slidingwindow(i->i, (rand(2,10),rand(9)), 1)
+        @test_throws DimensionMismatch slidingwindow(i->i, (rand(2,10),rand(4,9,10),rand(9)), 1)
+        @test_throws MethodError slidingwindow(i->i, EmptyType(), 1)
+        @test_throws MethodError slidingwindow(i->i, EmptyType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow(i->i, EmptyType(), 1, ObsDim.Undefined())
+        @test_throws MethodError slidingwindow(i->i, EmptyType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow(i->i, (EmptyType(),EmptyType()))
+        @test_throws MethodError slidingwindow(i->i, CustomType(), 1, ObsDim.Last())
+        @test_throws MethodError slidingwindow(i->i, EmptyType(), 1, obsdim=1)
+        @test_throws MethodError slidingwindow(i->i, (EmptyType(),EmptyType()), 1)
+
+        for var in (vars..., tuples..., Xs, ys)
+            @test_throws MethodError slidingwindow(i->i, var...)
+            @test_throws MethodError slidingwindow(i->i, var..., 1)
+            @test_throws MethodError slidingwindow(i->i, var..., obsdim=:last)
+            @test_throws MethodError slidingwindow(i->i, var..., 1, obsdim=:last)
+            @test_throws ArgumentError slidingwindow(i->i, var, 151)
+            @test_throws ArgumentError slidingwindow(i->i, var, 0)
+            @test_throws ArgumentError slidingwindow(i->i, var, 1, 0)
+            A = @inferred slidingwindow(identity, var, 5, 6)
+            @test A == slidingwindow(i->i, var, 5, stride = 6)
+            @test A == slidingwindow(i->i, var, 5, stride = 6, excludetarget=false)
+            @test typeof(A) == typeof(slidingwindow(identity, var, 5, stride = 6, excludetarget=false))
+            @test typeof(A) != typeof(slidingwindow(identity, var, 5, stride = 6, excludetarget=true))
+            @test @inferred(length(A)) == A.count == 25
+            @test A.size == 5
+            @test A.stride == 6
+            @test A.offset == 0
+            @test A.obsdim == LearnBase.default_obsdim(var)
+            @test @inferred(nobs(A)) == length(A)
+            @test @inferred(parent(A)) === var
+            A = @inferred(slidingwindow(i->i, var, 4))
+            @test A == slidingwindow(i->i, var, 4, stride = 4)
+            @test length(A) == A.count == 37
+            @test A.size == 4
+            @test A.stride == 4
+            @test A.offset == 0
+            @test A.obsdim == LearnBase.default_obsdim(var)
+            @test nobs(A) == length(A)
+            @test @inferred(parent(A)) === var
+        end
+        @test slidingwindow(i->i,(X,X), 5) == @inferred(slidingwindow(i->i,(X,X), 5, (ObsDim.Last(),ObsDim.Last())))
+        @test slidingwindow(i->i,(X,X), 5) == @inferred(slidingwindow(i->i,(X,X), 5, Val{false}))
+        @test slidingwindow(i->i,(X,X), 5) == @inferred(slidingwindow(i->i,(X,X), 5, 5, (ObsDim.Last(),ObsDim.Last())))
+        @test slidingwindow(i->i,(X,X), 5) == @inferred(slidingwindow(i->i,(X,X), 5, 5, Val{false}))
+        if Int == Int64
+            @test_reference "references/labeledslidingwindow.txt" @io2str show(::IO, MIME"text/plain"(), slidingwindow(identity, 1:6, 3, 2))
+        end
+        A = slidingwindow(i->i,X',5,obsdim=1)
+        @test A.size == 5
+        @test A.stride == 5
+        @test A.offset == 0
+        @test A.obsdim == LearnBase.ObsDim.First()
+        @test A == @inferred(slidingwindow(i->i,X',5,ObsDim.First()))
+        @test A == @inferred(slidingwindow(i->i,X',5,5,ObsDim.First()))
+        @test A == slidingwindow(i->i,X',5,obsdim=:first)
+        @test A == slidingwindow(i->i,X',5,stride=5,obsdim=:first)
+    end
+
+    println("<HEARTBEAT>")
+
+    @testset "typestability" begin
+        @test_throws ErrorException @inferred(slidingwindow(identity, X, 5, obsdim=2))
+        for var in (vars..., tuples..., Xs, ys)
+            @test typeof(@inferred(slidingwindow(identity, var, 5))) <: MLDataPattern.LabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(identity, var, 5, 3))) <: MLDataPattern.LabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(identity, var, 5, ObsDim.Last()))) <: MLDataPattern.LabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(identity, var, 5, 3, ObsDim.Last()))) <: MLDataPattern.LabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(identity, var, 5))) <: MLDataPattern.LabeledSlidingWindow
+            @test_throws ErrorException @inferred(slidingwindow(identity, var, 5, obsdim=:last))
+        end
+        for tup in tuples
+            @test typeof(@inferred(slidingwindow(identity,tup,5,(fill(ObsDim.Last(),length(tup))...)))) <: MLDataPattern.LabeledSlidingWindow
+            @test typeof(@inferred(slidingwindow(identity,tup,5,3,(fill(ObsDim.Last(),length(tup))...)))) <: MLDataPattern.LabeledSlidingWindow
+        end
+        @test typeof(@inferred(slidingwindow(identity,CustomType(),5))) <: MLDataPattern.LabeledSlidingWindow
+        @test typeof(@inferred(slidingwindow(identity,CustomType(), 5, ObsDim.Undefined()))) <: MLDataPattern.LabeledSlidingWindow
+    end
+
+    println("<HEARTBEAT>")
+
+    @testset "AbstractArray interface" begin
+        for var in (vars..., tuples..., Xs, ys)
+            A = slidingwindow(i->i+5, var, 5)
+            @test_throws BoundsError A[-1]
+            @test_throws BoundsError A[length(A)+1]
+            @test @inferred(nobs(A)) == 29
+            @test @inferred(length(A)) == 29
+            @test @inferred(size(A)) == (29,)
+            ref = [
+                (datasubset(var,(1*5+1):(2*5)), datasubset(var,2*5+1)),
+                (datasubset(var,(2*5+1):(3*5)), datasubset(var,3*5+1))
+            ]
+            @test @inferred(A[2:3]) == ref
+            @test eltype(A[2:3]) == typeof(ref[1])
+            ref = [
+                (datasubset(var,(0*5+1):(1*5)), datasubset(var,1*5+1)),
+                (datasubset(var,(2*5+1):(3*5)), datasubset(var,3*5+1))
+            ]
+            @test @inferred(A[[1,3]]) == ref
+            ref = (datasubset(var,(0*5+1):(1*5)), datasubset(var,1*5+1))
+            @test @inferred(A[1]) == ref
+            ref = (datasubset(var,(28*5+1):(29*5)), datasubset(var,29*5+1))
+            @test @inferred(A[29]) == ref
+            @test A[end] == A[29]
+            ref = (getobs(var,1:5), getobs(var,6))
+            @test @inferred(getobs(A,1)) == ref
+            @test typeof(getobs(A,1)) == typeof(ref)
+            ref = [
+                (getobs(var,(1*5+1):(2*5)), getobs(var,2*5+1)),
+                (getobs(var,(2*5+1):(3*5)), getobs(var,3*5+1))
+            ]
+            @test @inferred(getobs(A,2:3)) == ref
+            @test typeof(getobs(A,2:3)) == typeof(ref)
+            @test typeof(@inferred(collect(A))) <: Vector
+            # custom stride
+            A = slidingwindow(i->i-1, var, 5, 2)
+            @test_throws BoundsError A[-1]
+            @test_throws BoundsError A[length(A)+1]
+            @test @inferred(nobs(A)) == 72
+            @test @inferred(length(A)) == 72
+            @test @inferred(size(A)) == (72,)
+            @test A[end] == A[72]
+            ref = (getobs(var,3:3+4), getobs(var,2))
+            @test @inferred(getobs(A,1)) == ref
+            ref = [
+                (getobs(var,5:5+4), getobs(var,4)),
+                (getobs(var,7:7+4), getobs(var,6)),
+            ]
+            @test @inferred(getobs(A,2:3)) == ref
+            @test typeof(@inferred(collect(A))) <: Vector
+            # TODO: exclude target
+        end
+    end
+end

--- a/test/tst_slidingwindow.jl
+++ b/test/tst_slidingwindow.jl
@@ -326,6 +326,55 @@ end
 
     println("<HEARTBEAT>")
 
+    @testset "batchview" begin
+        # number as target
+        sw = slidingwindow(i->i+5, 1:31, 5)
+        @test length(sw) == 6
+        bv = @inferred batchview(sw, 2)
+        @test_throws MethodError shuffleobs(bv)
+        @test_throws MethodError splitobs(bv)
+        @test_throws MethodError oversample(bv)
+        @test_throws MethodError undersample(bv)
+        @test_throws MethodError stratifiedobs(bv)
+        @test length(bv) == 3
+        @test nobs(bv) == 6
+        tx, ty = @inferred bv[1]
+        @test tx isa Array{<:SubArray}
+        @test ty isa Array{<:SubArray}
+        @test tx == [[1,6],[2,7],[3,8],[4,9],[5,10]]
+        @test ty == [[6,11]]
+        tx, ty = @inferred bv[2]
+        @test tx == [[11,16],[12,17],[13,18],[14,19],[15,20]]
+        @test ty == [[16,21]]
+        tx, ty = @inferred bv[3]
+        @test tx == [[21,26],[22,27],[23,28],[24,29],[25,30]]
+        @test ty == [[26,31]]
+        # also test with array as target
+        sw = slidingwindow(i->i.+(5:6), 1:32, 5)
+        @test length(sw) == 6
+        bv = @inferred batchview(sw, 2)
+        @test_throws MethodError shuffleobs(bv)
+        @test_throws MethodError splitobs(bv)
+        @test_throws MethodError oversample(bv)
+        @test_throws MethodError undersample(bv)
+        @test_throws MethodError stratifiedobs(bv)
+        @test length(bv) == 3
+        @test nobs(bv) == 6
+        tx, ty = @inferred bv[1]
+        @test tx isa Array{<:SubArray}
+        @test ty isa Array{<:SubArray}
+        @test tx == [[1,6],[2,7],[3,8],[4,9],[5,10]]
+        @test ty == [[6,11],[7,12]]
+        tx, ty = @inferred bv[2]
+        @test tx == [[11,16],[12,17],[13,18],[14,19],[15,20]]
+        @test ty == [[16,21],[17,22]]
+        tx, ty = @inferred bv[3]
+        @test tx == [[21,26],[22,27],[23,28],[24,29],[25,30]]
+        @test ty == [[26,31],[27,32]]
+    end
+
+    println("<HEARTBEAT>")
+
     @testset "special values" begin
         A = @inferred slidingwindow(i->i+2, 1:10, 2)
         @test length(A) == 4

--- a/test/tst_splitobs.jl
+++ b/test/tst_splitobs.jl
@@ -133,3 +133,21 @@ println("<HEARTBEAT>")
     @test all(getobs(train[1])' .== train[2])
     @test all(getobs(test[1])' .== test[2])
 end
+
+@testset "ObsView" begin
+    A = ObsView(X)
+    b, c = @inferred splitobs(A, .7)
+    @test b isa ObsView
+    @test c isa ObsView
+    @test b == A[1:105]
+    @test c == A[106:end]
+end
+
+@testset "BatchView" begin
+    A = BatchView(X, 5)
+    b, c = @inferred splitobs(A, .6)
+    @test b isa BatchView
+    @test c isa BatchView
+    @test b == A[1:18]
+    @test c == A[19:end]
+end

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -79,3 +79,15 @@ end
     @test train == [:c, :a, :a, :a, :b, :b] || train == [:a, :a, :a, :c, :b, :b] || train == [:b, :b, :c, :a, :a, :a] || train == [:c, :b, :b, :a, :a, :a] || train == [:b, :b, :a, :a, :a, :c] || train == [:a, :a, :a, :b, :b, :c]
     @test test == [:c, :a, :a, :a, :b, :b] || test == [:a, :a, :a, :c, :b, :b] || test == [:b, :b, :c, :a, :a, :a] || test == [:c, :b, :b, :a, :a, :a] || test == [:b, :b, :a, :a, :a, :c] || test == [:a, :a, :a, :b, :b, :c]
 end
+
+@testset "ObsView" begin
+    ty = obsview([:a, :a, :a, :a, :a, :a, :b, :b, :b, :b])
+    train, test = getobs.(@inferred(stratifiedobs(ty, 0.5, false)))
+    @test train == [:a, :a, :a, :b, :b] || train == [:b, :b, :a, :a, :a]
+    @test test == [:a, :a, :a, :b, :b] || test == [:b, :b, :a, :a, :a]
+
+    train, test, val = getobs.(@inferred(stratifiedobs(ty, (0.5,0.3), false)))
+    @test train == [:a, :a, :a, :b, :b] || train == [:b, :b, :a, :a, :a]
+    @test test == [:a, :a, :b] || test == [:b, :a, :a]
+    @test val == [:a, :b] || val == [:b, :a]
+end


### PR DESCRIPTION
- [x] docstrings for `slidingwindow`
- [x] tests for `batchview` of a unlabeled sliding window
- [x] tests for `batchview` of a labeled sliding window
- [x] mention in documentation
- [x] fix `shuffleobs(batchview(slidingwindow(...)))`, which is broken