### PR TITLE
add fraction control to oversample

### DIFF
--- a/docs/documentation/targets.rst
+++ b/docs/documentation/targets.rst
@@ -1030,14 +1030,14 @@ the smaller classes instead. To that end, we provide the function
 apparent size of the given data container, it does use the same
 exact observations multiple times.
 
-.. function:: oversample([fun], data, [shuffle], [obsdim])
+.. function:: oversample([fun], data, [fraction], [shuffle], [obsdim])
 
-   Generates a class-balanced version of `data` by repeatedly
-   sampling existing observations in such a way that the
-   resulting number of observations will be the same number for
-   every class. This way, all classes will have as many
-   observations in the resulting data subset as the largest class
-   has in the given (i.e. original) `data` container.
+   Generate a re-balanced version of `data` by repeatedly
+   sampling existing observations in such a way that every class
+   will have at least `fraction` times the number observations of
+   the largest class. This way, all classes will have a minimum
+   number of observations in the resulting data set relative to
+   what largest class has in the given (i.e. original) `data`.
 
    :param fun: \
         Optional. A callable object (usually a function) that
@@ -1046,6 +1046,12 @@ exact observations multiple times.
         observation.
 
    :param data: The object representing a labeled data container.
+
+   :param Real fraction: \
+        Optional. Minimum number of observations (as a fraction
+        relative to the largest class) that every class should
+        have. Defaults to ``1``, which implies completely
+        balanced.
 
    :param bool shuffle: \
         Optional. Determines if the resulting data will be
@@ -1061,9 +1067,9 @@ exact observations multiple times.
         convenient keyword parameter. See :ref:`obsdim` for more
         information.
 
-   :return: An up-sampled, class-balanced version of `data` in the
-            form of a lazy data subset. No data is copied until
-            :func:`getobs` is called.
+   :return: An up-sampled version of `data` in the form of a lazy
+            data subset. No data is copied until :func:`getobs`
+            is called.
 
 Let us again consider the toy data set from before, which
 consists of a feature matrix ``X`` and a corresponding target

--- a/test/tst_resample.jl
+++ b/test/tst_resample.jl
@@ -28,13 +28,20 @@ lett = ["a","b","b","c","c","c","d","d","d","d","d"]
         @testset "Vector of $(eltype(vals)); shuffle=true" begin
             for res in (
                     @inferred(oversample(vals)),
+                    @inferred(oversample(vals, 1)),
+                    @inferred(oversample(vals, 1, ObsDim.First())),
+                    @inferred(oversample(vals, 1, true)),
+                    @inferred(oversample(vals, 1, true, ObsDim.First())),
                     @inferred(oversample(vals, true)),
                     @inferred(oversample(vals, true, ObsDim.First())),
                     @inferred(oversample(identity, vals)),
                     @inferred(oversample(identity, vals, true)),
+                    @inferred(oversample(identity, vals, 1)),
+                    @inferred(oversample(identity, vals, 1, true)),
                     @inferred(oversample(identity, vals, true, ObsDim.First())),
-                    oversample(vals, shuffle=true, obsdim=1),
-                    oversample(identity, vals, shuffle=true, obsdim=1)
+                    @inferred(oversample(identity, vals, 1, true, ObsDim.First())),
+                    oversample(vals, fraction=1, shuffle=true, obsdim=1),
+                    oversample(identity, vals, fraction=1, shuffle=true, obsdim=1)
                 )
                 @test typeof(res) <: SubArray{eltype(vals),1}
                 @test length(res) == 20
@@ -50,11 +57,16 @@ lett = ["a","b","b","c","c","c","d","d","d","d","d"]
         @testset "Vector of $(eltype(vals)); shuffle=false" begin
             for res in (
                     @inferred(oversample(vals, false)),
+                    @inferred(oversample(vals, 1, false)),
                     @inferred(oversample(vals, false, ObsDim.First())),
+                    @inferred(oversample(vals, 1, false, ObsDim.First())),
                     @inferred(oversample(identity, vals, false)),
+                    @inferred(oversample(identity, vals, 1, false)),
                     @inferred(oversample(identity, vals, false, ObsDim.First())),
+                    @inferred(oversample(identity, vals, 1, false, ObsDim.First())),
                     oversample(vals, shuffle=false, obsdim=1),
-                    oversample(identity, vals, shuffle=false, obsdim=1)
+                    oversample(vals, fraction=1, shuffle=false, obsdim=1),
+                    oversample(identity, vals, fraction=1, shuffle=false, obsdim=1)
                 )
                 @test typeof(res) <: SubArray{eltype(vals),1}
                 @test length(res) == 20
@@ -70,12 +82,26 @@ lett = ["a","b","b","c","c","c","d","d","d","d","d"]
     end
 
     @testset "Basic" begin
-        n_src = 200
-        src = rand([1, 2,2, 3,3,3, 4,4,4,4], n_src)
+        #n_src = 200
+        src = [1, 2,2,2, 3,3,3,3,3, 4,4,4,4,4,4,4,4]
         oversampled = oversample(src)
         @test all(counts(oversampled).==counts(oversampled)[1])
         @test all(x ∈ oversampled for x in unique(src))
-        @test length(oversampled) > n_src
+        @test length(oversampled) > length(src)
+        oversampled = oversample(src, 0.5)
+        @test countmap(oversampled, alg = :dict) == Dict(4=>8,2=>4,3=>5,1=>4)
+        for oversampled in (
+                @inferred(oversample(src, 0.2)),
+                @inferred(oversample(src, 0.2, true)),
+                @inferred(oversample(src, 0.2, false)),
+                oversample(src, fraction=0.2),
+                @inferred(oversample(identity, src, 0.2)),
+                @inferred(oversample(identity, src, 0.2, false)),
+                oversample(identity, src, fraction=0.2),
+            )
+            @test all(counts(oversampled) .>= 2)
+            @test any(counts(oversampled) .<= 3)
+        end
     end
 
     @testset "ObsView" begin


### PR DESCRIPTION
allows more for control of how much oversampling to do

```julia
julia> using MLDataPattern, MLLabelUtils

julia> nums = [1,2,2,3,3,3,3,3,4,4,4,4,4,4,4,4,4,4,4];

julia> labelfreq(nums)
Dict{Int64,Int64} with 4 entries:
  4 => 11
  2 => 2
  3 => 5
  1 => 1

julia> labelfreq(oversample(nums))
Dict{Int64,Int64} with 4 entries:
  4 => 11
  2 => 11
  3 => 11
  1 => 11

julia> labelfreq(oversample(nums, .5))
Dict{Int64,Int64} with 4 entries:
  4 => 11
  2 => 6
  3 => 6
  1 => 6

julia> labelfreq(oversample(nums, .3))
Dict{Int64,Int64} with 4 entries:
  4 => 11
  2 => 3
  3 => 5
  1 => 3
```