### PR TITLE
fix _compute_batch_settings to not overwrite count with max_batchcount

### DIFF
--- a/src/dataview.jl
+++ b/src/dataview.jl
@@ -195,7 +195,6 @@ function _compute_batch_settings(source, size::Int = -1, count::Int = -1, obsdim
         # use count just for boundscheck
         max_batchcount = floor(Int, num_observations / size)
         count <= max_batchcount || throw(ArgumentError("Specified number of partitions is too large for the specified size"))
-        count = max_batchcount
     end
 
     # check if the settings will result in all data points being used


### PR DESCRIPTION
According to the docs:
```julia
  using MLDataUtils
  X, Y = MLDataUtils.load_iris()
  # iterate over the first 2 batches of 15 observation each
  for (x,y) in batchview((X,Y), size=15, count=2)
      @assert typeof(x) <: SubArray{Float64,2}
      @assert typeof(y) <: SubArray{String,1}
      @assert size(x) == (4, 15)
      @assert size(y) == (15,)
  end
```
Indicating that the call above to batchview should return an iterator of length `2`. Instead, it loads an iterator of length 10. This is because the `count` argument is overwritten in _compute_batch_settings. This PR removes that line.

