### PR TITLE
Deprecate >= notation in compat section

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '20 00 * * *'
+  issues:
+    types: [opened, reopened]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: ["1.0"]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
+    steps:
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.julia-version }}
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,8 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
 LearnBase = "~0.2.0"
-MLLabelUtils = "≥ 0.4.0"
-StatsBase = "≥ 0.24.0"
+MLLabelUtils = "0.4, 0.5"
+StatsBase = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.30, 0.31, 0.32"
 julia = "0.7, 1"
 
 [extras]


### PR DESCRIPTION
`>=` is now interpreted as \infty. Although this reduces maintenance
work, it can easily break the package due to package incompatibility.

CompatHelper can help detect new dependency versions and open a PR for
that, thus using the caret specifiers (e.g., `0.24`) is recommended.

Besides this PR, we may also need to modify the general registry:

```diff
["0.5"]
- LearnBase = "0.2-0"
- MLLabelUtils = "0.4-0"
- StatsBase = "0.24-0"
+ LearnBase = "0.2"
+ MLLabelUtils = "0.4-0.5"
+ StatsBase = "0.24-0.32"
julia = ["0.7", "1"]
```

@Evizero Do these look okay to you? Also, can you install the [Registrator](https://github.com/JuliaRegistries/Registrator.jl) for JuliaML?

---

Another issue: probably we need a minor version bump to not keep julia v0.7 compatible.