### PR TITLE
Add rng parameter to shuffleobs and stratifiedobs

### DIFF
--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -35,7 +35,7 @@ for more information.
 shuffleobs(data; obsdim = default_obsdim(data), rng::AbstractRNG = Random.default_rng()) =
     shuffleobs(data, convert(LearnBase.ObsDimension,obsdim), rng)
 
-function shuffleobs(data, obsdim, rng::AbstractRNG)
+function shuffleobs(data, obsdim, rng::AbstractRNG = Random.default_rng())
     allowcontainer(shuffleobs, data) || throw(MethodError(shuffleobs, (data,obsdim)))
     datasubset(data, randperm(rng, nobs(data, obsdim)), obsdim)
 end

--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -32,10 +32,10 @@ For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref). See [`DataSubset`](@ref)
 for more information.
 """
-shuffleobs(data; obsdim = default_obsdim(data), rng::AbstractRNG = Random.default_rng()) =
+shuffleobs(data; obsdim = default_obsdim(data), rng::AbstractRNG = Random.GLOBAL_RNG) =
     shuffleobs(data, convert(LearnBase.ObsDimension,obsdim), rng)
 
-function shuffleobs(data, obsdim, rng::AbstractRNG = Random.default_rng())
+function shuffleobs(data, obsdim, rng::AbstractRNG = Random.GLOBAL_RNG)
     allowcontainer(shuffleobs, data) || throw(MethodError(shuffleobs, (data,obsdim)))
     datasubset(data, randperm(rng, nobs(data, obsdim)), obsdim)
 end

--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -1,5 +1,5 @@
 """
-    shuffleobs(data, [obsdim])
+    shuffleobs(data, [obsdim], [rng])
 
 Return a "subset" of `data` that spans all observations, but
 has the order of the observations shuffled.
@@ -22,6 +22,11 @@ end
 The optional (keyword) parameter `obsdim` allows one to specify
 which dimension denotes the observations. see `LearnBase.ObsDim`
 for more detail.
+
+The optional (keyword) parameter `rng` allows one to specify the
+random number generator used for shuffling. This is useful when
+reproducible results are desired. By default, uses the global RNG.
+See `Random` in Julia's standard library for more info.
 
 For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref). See [`DataSubset`](@ref)

--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -27,10 +27,10 @@ For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref). See [`DataSubset`](@ref)
 for more information.
 """
-shuffleobs(data; obsdim = default_obsdim(data)) =
-    shuffleobs(data, convert(LearnBase.ObsDimension,obsdim))
+shuffleobs(data; obsdim = default_obsdim(data), rng::AbstractRNG = Random.default_rng()) =
+    shuffleobs(data, convert(LearnBase.ObsDimension,obsdim), rng)
 
-function shuffleobs(data, obsdim)
+function shuffleobs(data, obsdim, rng::AbstractRNG)
     allowcontainer(shuffleobs, data) || throw(MethodError(shuffleobs, (data,obsdim)))
-    datasubset(data, randperm(nobs(data, obsdim)), obsdim)
+    datasubset(data, randperm(rng, nobs(data, obsdim)), obsdim)
 end

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -47,7 +47,7 @@ end
 end
 
 """
-    stratifiedobs([f], data, [p = 0.7], [shuffle = true], [obsdim]) -> Tuple
+    stratifiedobs([f], data, [p = 0.7], [shuffle = true], [obsdim], [rng]) -> Tuple
 
 Partition the `data` into multiple disjoint subsets proportional
 to the value(s) of `p`. The observations are assignmed to a data
@@ -123,6 +123,35 @@ julia> X = [1 0; 1 0; 1 0; 1 0; 0 1; 0 1]
 
 julia> train, test = stratifiedobs(argmax, X, p = 0.5, obsdim = 1)
 ([1 0; 1 0; 0 1], [0 1; 1 0; 1 0])
+```
+
+The optional (keyword) parameter `rng` allows one to specify the
+random number generator used for shuffling. This is useful when
+reproducible results are desired. By default, uses the global RNG.
+See `Random` in Julia's standard library for more info.
+
+```julia
+using Random: MersenneTwister
+julia> X = [1:6;]
+6-element Array{Int64,1}:
+ 1
+ 2
+ 3
+ 4
+ 5
+ 6
+
+julia> y = [:a, :b, :b, :b, :b, :a]
+6-element Array{Symbol,1}:
+ :a
+ :b
+ :b
+ :b
+ :b
+ :a
+
+julia> train, test = stratifiedobs((x, y), rng=MersenneTwister(42))
+(([5, 3, 1, 4], [:b, :b, :a, :b]), ([2, 6], [:b, :a]))
 ```
 
 For this function to work, the type of `data` must implement

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -130,7 +130,7 @@ random number generator used for shuffling. This is useful when
 reproducible results are desired. By default, uses the global RNG.
 See `Random` in Julia's standard library for more info.
 
-```julia
+```jldoctest; setup = :(using MLDataPattern)
 julia> using Random: MersenneTwister
 
 julia> X = [1:6;]

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -131,7 +131,8 @@ reproducible results are desired. By default, uses the global RNG.
 See `Random` in Julia's standard library for more info.
 
 ```julia
-using Random: MersenneTwister
+julia> using Random: MersenneTwister
+
 julia> X = [1:6;]
 6-element Array{Int64,1}:
  1

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -203,11 +203,11 @@ see [`DataSubset`](@ref) for more information on data subsets.
 
 see also [`undersample`](@ref), [`oversample`](@ref), [`splitobs`](@ref).
 """
-function stratifiedobs(data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.default_rng())
+function stratifiedobs(data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.GLOBAL_RNG)
     stratifiedobs(identity, data, p, shuffle, convert(ObsDimension, obsdim), rng)
 end
 
-function stratifiedobs(f, data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.default_rng())
+function stratifiedobs(f, data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.GLOBAL_RNG)
     stratifiedobs(f, data, p, shuffle, convert(ObsDimension, obsdim))
 end
 
@@ -219,7 +219,7 @@ function stratifiedobs(data, p::NTuple{N,AbstractFloat}, args...) where N
     stratifiedobs(identity, data, p, args...)
 end
 
-function stratifiedobs(f, data, p::Union{NTuple,AbstractFloat}, shuffle::Bool = true, obsdim = default_obsdim(data), rng::AbstractRNG = Random.default_rng())
+function stratifiedobs(f, data, p::Union{NTuple,AbstractFloat}, shuffle::Bool = true, obsdim = default_obsdim(data), rng::AbstractRNG = Random.GLOBAL_RNG)
     # The given data is always shuffled to qualify as performing
     # stratified sampling without replacement.
     data_shuf = shuffleobs(data, obsdim, rng)

--- a/test/tst_shuffleobs.jl
+++ b/test/tst_shuffleobs.jl
@@ -111,3 +111,13 @@ end
     @test bv isa BatchView{<:SubArray,<:SubArray}
     @test vec(sum(sum(bv),dims=2)) == fill(11325,10)
 end
+
+Random.seed!(42)
+@testset "RNG" begin
+    # tests reproducibility using explicit and global RNGs
+    default_shuffle = shuffleobs((X, y))
+    explicit_shuffle = shuffleobs((X, y), rng=MersenneTwister(42))
+    @test default_shuffle == explicit_shuffle
+    # test that explicit shuffling produces the same result everytime
+    @test explicit_shuffle == shuffleobs((X, y), rng=MersenneTwister(42))
+end

--- a/test/tst_stratifiedobs.jl
+++ b/test/tst_stratifiedobs.jl
@@ -91,3 +91,14 @@ end
     @test test == [:a, :a, :b] || test == [:b, :a, :a]
     @test val == [:a, :b] || val == [:b, :a]
 end
+
+Random.seed!(42)
+@testset "RNG" begin
+    # tests reproducibility using explicit and global RNGs
+    tX = [1:20;]
+    ty = [:b, :b, :a, :b, :b, :b, :b, :a, :b, :a, :b, :b, :b, :a, :a, :b, :b, :b, :b, :b]
+    (def_train_x, def_train_y), (def_test_x, def_test_y) = stratifiedobs((tX, ty))
+    (exp_train_x, exp_train_y), (exp_test_x, exp_test_y) = stratifiedobs((tX, ty), rng=MersenneTwister(42))
+    @test ((def_train_x, def_train_y), (def_test_x, def_test_y)) == ((exp_train_x, exp_train_y), (exp_test_x, exp_test_y))
+    @test ((exp_train_x, exp_train_y), (exp_test_x, exp_test_y)) == stratifiedobs((tX, ty), rng=MersenneTwister(42))
+end


### PR DESCRIPTION
`shuffleobs` and `stratifiedobs` can now accept an optional `rng` parameter. `rng (<: Random.AbstractRNG)` is passed to the `randperm` and `shuffle!` functions. This makes results reproducible without modifying the seed of the global RNG. Fixes #42.

I have run tests using `test MLDataPattern` at the package prompt, but I have no experience of writing tests of my own. I'd appreciate advice regarding any new tests required or modifying the existing ones. 

Also, I didn't find any guidelines for contributing, so let me know if anything else needs to be added here.