### PR TITLE
Updated to reflect new LearnBase interface for getobs and ObsDim

### DIFF
--- a/src/MLDataPattern.jl
+++ b/src/MLDataPattern.jl
@@ -3,16 +3,13 @@ using StatsBase
 using LearnBase
 using MLLabelUtils
 
-using LearnBase: ObsDimension
-import LearnBase: nobs, getobs, getobs!, gettarget, gettargets, targets, datasubset, default_obsdim
+import LearnBase: getobs, getobs!, gettarget, gettargets, targets, datasubset, default_obsdim
 
 using Base.Cartesian
 using Random
 using SparseArrays
 
 export
-
-    ObsDim,
 
     nobs,
     getobs,
@@ -35,8 +32,8 @@ export
     SlidingWindow,
     slidingwindow,
 
-    targets,
-    eachtarget,
+    # targets,
+    # eachtarget,
 
     stratifiedobs,
 
@@ -56,11 +53,11 @@ export
     eachobs,
     eachbatch
 
-obsdim_string(::ObsDim.First) = ":first"
-obsdim_string(::ObsDim.Last) = ":last"
-obsdim_string(::ObsDim.Constant{D}) where {D} = string(D)
-obsdim_string(::ObsDim.Undefined) = "\"NA\""
-obsdim_string(obsdim::Tuple) = string("(", join(map(obsdim_string, obsdim), ", "), ")")
+# obsdim_string(::ObsDim.First) = ":first"
+# obsdim_string(::ObsDim.Last) = ":last"
+# obsdim_string(::ObsDim.Constant{D}) where {D} = string(D)
+# obsdim_string(::ObsDim.Undefined) = "\"NA\""
+# obsdim_string(obsdim::Tuple) = string("(", join(map(obsdim_string, obsdim), ", "), ")")
 
 include("container.jl")
 include("datasubset.jl")

--- a/src/randobs.jl
+++ b/src/randobs.jl
@@ -14,13 +14,10 @@ For this function to work, the type of `data` must implement
 [`nobs`](@ref) and [`getobs`](@ref).
 """
 randobs(data; obsdim = default_obsdim(data)) =
-    randobs(data, convert(LearnBase.ObsDimension,obsdim))
+    randobs(data, 1, obsdim)
 
 randobs(data, n; obsdim = default_obsdim(data)) =
-    randobs(data, n, convert(LearnBase.ObsDimension,obsdim))
+    randobs(data, n, obsdim)
 
-randobs(data, obsdim::Union{Tuple,ObsDimension}) =
-    getobs(data, rand(1:nobs(data, obsdim)), obsdim)
-
-randobs(data, n, obsdim::Union{Tuple,ObsDimension}) =
+randobs(data, n, obsdim) =
     getobs(data, rand(1:nobs(data, obsdim), n), obsdim)

--- a/src/resample.jl
+++ b/src/resample.jl
@@ -87,7 +87,7 @@ see [`DataSubset`](@ref) for more information on data subsets.
 see also [`undersample`](@ref) and [`stratifiedobs`](@ref).
 """
 oversample(data; fraction=1, shuffle=true, obsdim=default_obsdim(data)) =
-    oversample(identity, data, fraction, shuffle, convert(LearnBase.ObsDimension,obsdim))
+    oversample(identity, data, fraction, shuffle, obsdim)
 
 oversample(data, shuffle::Bool, obsdim=default_obsdim(data)) =
     oversample(identity, data, shuffle, obsdim)
@@ -99,7 +99,7 @@ oversample(data, fraction::Real, shuffle::Bool, obsdim=default_obsdim(data)) =
     oversample(identity, data, fraction, shuffle, obsdim)
 
 oversample(f, data; fraction=1, shuffle=true, obsdim=default_obsdim(data)) =
-    oversample(f, data, fraction, shuffle, convert(LearnBase.ObsDimension,obsdim))
+    oversample(f, data, fraction, shuffle, obsdim)
 
 oversample(f, data, shuffle::Bool, obsdim=default_obsdim(data)) =
     oversample(identity, data, 1, shuffle, obsdim)
@@ -209,13 +209,13 @@ see [`DataSubset`](@ref) for more information on data subsets.
 see also [`oversample`](@ref) and [`stratifiedobs`](@ref).
 """
 undersample(data; shuffle=false, obsdim=default_obsdim(data)) =
-    undersample(identity, data, shuffle, convert(LearnBase.ObsDimension,obsdim))
+    undersample(identity, data, shuffle, obsdim)
 
 undersample(data, shuffle::Bool, obsdim=default_obsdim(data)) =
     undersample(identity, data, shuffle, obsdim)
 
 undersample(f, data; shuffle=false, obsdim=default_obsdim(data)) =
-    undersample(f, data, shuffle, convert(LearnBase.ObsDimension,obsdim))
+    undersample(f, data, shuffle, obsdim)
 
 function undersample(f, data, shuffle::Bool, obsdim=default_obsdim(data))
     allowcontainer(undersample, data) || throw(MethodError(undersample, (f,data,shuffle,obsdim)))

--- a/src/shuffleobs.jl
+++ b/src/shuffleobs.jl
@@ -33,7 +33,7 @@ For this function to work, the type of `data` must implement
 for more information.
 """
 shuffleobs(data; obsdim = default_obsdim(data), rng::AbstractRNG = Random.GLOBAL_RNG) =
-    shuffleobs(data, convert(LearnBase.ObsDimension,obsdim), rng)
+    shuffleobs(data, obsdim, rng)
 
 function shuffleobs(data, obsdim, rng::AbstractRNG = Random.GLOBAL_RNG)
     allowcontainer(shuffleobs, data) || throw(MethodError(shuffleobs, (data,obsdim)))

--- a/src/splitobs.jl
+++ b/src/splitobs.jl
@@ -111,7 +111,7 @@ see [`stratifiedobs`](@ref) for a related function that preserves
 the target distribution.
 """
 splitobs(data; at = 0.7, obsdim = default_obsdim(data)) =
-    splitobs(data, at, convert(LearnBase.ObsDimension,obsdim))
+    splitobs(data, at, obsdim)
 
 # partition into 2 sets
 function splitobs(data, at::AbstractFloat, obsdim=default_obsdim(data))

--- a/src/stratifiedobs.jl
+++ b/src/stratifiedobs.jl
@@ -204,11 +204,11 @@ see [`DataSubset`](@ref) for more information on data subsets.
 see also [`undersample`](@ref), [`oversample`](@ref), [`splitobs`](@ref).
 """
 function stratifiedobs(data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.GLOBAL_RNG)
-    stratifiedobs(identity, data, p, shuffle, convert(ObsDimension, obsdim), rng)
+    stratifiedobs(identity, data, p, shuffle, obsdim, rng)
 end
 
 function stratifiedobs(f, data; p = 0.7, shuffle = true, obsdim = default_obsdim(data), rng = Random.GLOBAL_RNG)
-    stratifiedobs(f, data, p, shuffle, convert(ObsDimension, obsdim), rng)
+    stratifiedobs(f, data, p, shuffle, obsdim, rng)
 end
 
 function stratifiedobs(data, p::AbstractFloat, args...)


### PR DESCRIPTION
This is a WIP in response to https://github.com/JuliaML/LearnBase.jl/pull/44. The changes to the LearnBase.jl interface reduce the MLDataPattern.jl codebase significantly. Most notably, we are able to avoid a lot of the routing logic for `getobs`.

Since there are other JuliaML packages that will need similar updates, I want to summarize the highlights of what this transition entails:
- Most of it is removing `convert(LearnBase.ObsDimension, obsdim)` statements; `obsdim` now has no type restrictions.
- For a lot of array code, generated functions were used to create views based on the `obsdim` type. This is no longer necessary, and you can directly call `selectdim(A, idx, obsdim)` from Base. In some crude testing, I found no performance regressions from doing this. `selectdim` essentially does the views + colon tricks that the generated functions used to do.
- Make sure to remove definitions for `getobs(x)`, `getobs(x, obsdim)`, and `nobs(x)` from the code. The only interface functions to implement are `getobs(x, idx, obsdim)` and `nobs(x, obsdim)` (*note:* this may change slightly based on the LearnBase.jl PR but deleting the above methods is still valid.
- If most of the JuliaML packages are structured similar to MLDataPattern.jl, then the bulk of the changes will be in one or two files.

There are still some parts I haven't addressed like `gettarget` and `BatchView`. There are no technical challenges here; I just haven't gotten to them. We'll want to get those changes in too before merging.